### PR TITLE
chore: refactor deserializeValue and test utilities

### DIFF
--- a/src/decdk.ts
+++ b/src/decdk.ts
@@ -1,12 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import chalk from 'chalk';
 import yargs from 'yargs';
-import {
-  DeclarativeStack,
-  loadTypeSystem,
-  readTemplate,
-  stackNameFromFileName,
-} from '.';
+import { DeclarativeStack } from './declarative-stack';
+import { loadTypeSystem, readTemplate, stackNameFromFileName } from './util';
 
 async function main() {
   const argv = await yargs

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -355,8 +355,24 @@ function deconstructEnum(options: DeconstructCommonOptions) {
     return undefined;
   }
 
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Enum choice must be a string literal, found ${JSON.stringify(value)}.`
+    );
+  }
+
+  const enumChoice = value.toUpperCase();
   const enumType = resolveType(typeRef.type.fqn);
-  return enumType[value];
+
+  if (!(enumChoice in enumType)) {
+    throw new Error(
+      `Could not find enum choice ${enumChoice} for enum type ${
+        typeRef.type.fqn
+      }. Available options: [${Object.keys(enumType).join(', ')}]`
+    );
+  }
+
+  return enumType[enumChoice];
 }
 
 function deconstructInterface(options: DeconstructCommonOptions) {

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -214,24 +214,9 @@ function deconstructValue(options: DeconstructValueOptions): any {
     );
   }
 
-  // deserialize maps
-  if (typeRef.mapOfType) {
-    if (typeof value !== 'object') {
-      throw new ValidationError(`Expecting object for ${key} in ${typeRef}`);
-    }
-
-    const out: any = {};
-    for (const [k, v] of Object.entries(value)) {
-      out[k] = deconstructValue({
-        stack,
-        typeRef: typeRef.mapOfType,
-        optional: false,
-        key: `${key}.${k}`,
-        value: v,
-      });
-    }
-
-    return out;
+  const map = deconstructMap(options);
+  if (map) {
+    return map;
   }
 
   if (typeRef.unionOfTypes) {
@@ -317,6 +302,31 @@ function deconstructArray(options: DeconstructCommonOptions) {
       value: x,
     })
   );
+}
+
+function deconstructMap(options: DeconstructCommonOptions) {
+  const { stack, typeRef, key, value } = options;
+
+  if (!typeRef.mapOfType) {
+    return undefined;
+  }
+
+  if (typeof value !== 'object') {
+    throw new ValidationError(`Expecting object for ${key} in ${typeRef}`);
+  }
+
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(value)) {
+    out[k] = deconstructValue({
+      stack,
+      typeRef: typeRef.mapOfType,
+      optional: false,
+      key: `${key}.${k}`,
+      value: v,
+    });
+  }
+
+  return out;
 }
 
 function deconstructEnum(options: DeconstructCommonOptions) {

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -199,16 +199,9 @@ function deconstructValue(options: DeconstructValueOptions): any {
     return arr;
   }
 
-  const asRef = tryResolveRef(value);
-  if (asRef) {
-    if (isConstruct(typeRef)) {
-      return findConstruct(stack, value.Ref);
-    }
-
-    throw new Error(
-      `{ Ref } can only be used when a construct type is expected and this is ${typeRef}. ` +
-        'Use { Fn::GetAtt } to represent specific resource attributes'
-    );
+  const ref = deconstructRef(value);
+  if (ref) {
+    return ref;
   }
 
   const getAtt = tryResolveGetAtt(value);
@@ -268,6 +261,25 @@ function deconstructValue(options: DeconstructValueOptions): any {
 
   throw new Error(
     `Unable to deconstruct "${JSON.stringify(value)}" for type ref ${typeRef}`
+  );
+}
+
+function deconstructRef(options: DeconstructCommonOptions) {
+  const { stack, typeRef, value } = options;
+
+  const asRef = tryResolveRef(value);
+
+  if (!asRef) {
+    return undefined;
+  }
+
+  if (isConstruct(typeRef)) {
+    return findConstruct(stack, value.Ref);
+  }
+
+  throw new Error(
+    `{ Ref } can only be used when a construct type is expected and this is ${typeRef}. ` +
+      'Use { Fn::GetAtt } to represent specific resource attributes'
   );
 }
 

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -71,7 +71,7 @@ export class DeclarativeStack extends cdk.Stack {
           new Ctor(
             this,
             logicalId,
-            deserializeValue({
+            deconstructValue({
               stack: this,
               typeRef: propsTypeRef,
               optional: true,
@@ -151,7 +151,7 @@ function tryResolveGetAtt(value: any) {
   return fn.val;
 }
 
-interface DeserializeValueOptions {
+interface DeconstructValueOptions {
   readonly stack: cdk.Stack;
   readonly typeRef: reflect.TypeReference;
   readonly optional: boolean;
@@ -159,7 +159,7 @@ interface DeserializeValueOptions {
   readonly value: any;
 }
 
-function deserializeValue(options: DeserializeValueOptions): any {
+function deconstructValue(options: DeconstructValueOptions): any {
   const { stack, typeRef, optional, key, value } = options;
   // console.error('====== deserializer ===================');
   // console.error(`type: ${typeRef}`);
@@ -181,7 +181,7 @@ function deserializeValue(options: DeserializeValueOptions): any {
     }
 
     return value.map((x, i) =>
-      deserializeValue({
+      deconstructValue({
         stack,
         typeRef: typeRef.arrayOfType!,
         optional: false,
@@ -231,7 +231,7 @@ function deserializeValue(options: DeserializeValueOptions): any {
 
     const out: any = {};
     for (const [k, v] of Object.entries(value)) {
-      out[k] = deserializeValue({
+      out[k] = deconstructValue({
         stack,
         typeRef: typeRef.mapOfType,
         optional: false,
@@ -247,7 +247,7 @@ function deserializeValue(options: DeserializeValueOptions): any {
     const errors = new Array<any>();
     for (const x of typeRef.unionOfTypes) {
       try {
-        return deserializeValue({
+        return deconstructValue({
           stack,
           typeRef: x,
           optional,
@@ -342,7 +342,7 @@ function deconstructInterface(
       continue;
     }
 
-    out[prop.name] = deserializeValue({
+    out[prop.name] = deconstructValue({
       stack,
       typeRef: prop.type,
       optional: prop.optional,
@@ -490,7 +490,7 @@ function invokeMethod(
     if (i === method.parameters.length - 1 && isDataType(p.type.type)) {
       // we pass in all parameters are the value, and the positional arguments will be ignored since
       // we are promised there are no conflicts
-      const kwargs = deserializeValue({
+      const kwargs = deconstructValue({
         stack,
         typeRef: p.type,
         optional: p.optional,
@@ -508,7 +508,7 @@ function invokeMethod(
 
       if (value !== undefined) {
         args.push(
-          deserializeValue({
+          deconstructValue({
             stack,
             typeRef: p.type,
             optional: p.optional,

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -235,12 +235,6 @@ function deconstructValue(options: DeconstructValueOptions): any {
     return ifc;
   }
 
-  // if this is an enum type, use the name to dereference
-  if (typeRef.type instanceof reflect.EnumType) {
-    const enumType = resolveType(typeRef.type.fqn);
-    return enumType[value];
-  }
-
   if (typeRef.primitive) {
     return value;
   }

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -168,7 +168,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "15689ac064b611030f942500c2748f742e64ae1901db7bec75f6fbcb5924f628.zip",
+          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -990,7 +990,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "15689ac064b611030f942500c2748f742e64ae1901db7bec75f6fbcb5924f628.zip",
+          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
         },
         "Environment": Object {
           "Variables": Object {
@@ -1531,7 +1531,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "15689ac064b611030f942500c2748f742e64ae1901db7bec75f6fbcb5924f628.zip",
+          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -168,7 +168,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
+          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -990,7 +990,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
+          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
         },
         "Environment": Object {
           "Variables": Object {
@@ -1531,7 +1531,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6ef5cf0c971062be8ed96f7406ae464c95ca1a6b5c2700893dbebb30c9cea4ae.zip",
+          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`apigw.json: apigw 1`] = `
+exports[`apigw.json 1`] = `
 Object {
   "Outputs": Object {
     "MyApiEndpoint869ABE96": Object {
@@ -81,44 +81,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "GetRootApiPermissionTestapigwMyApiCBFBC5B0GET5B244F0C": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "HelloLambda3D9C82D6",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "MyApi49610EDF",
-              },
-              "/test-invoke-stage/GET/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "GetRootApiPermissionapigwMyApiCBFBC5B0GETC314E626": Object {
+    "GetRootApiPermissionTestMyApi8B2BE17AGET60A859EA": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -153,6 +116,43 @@ Object {
                 "Ref": "MyApiDeploymentStageprodE1054AF0",
               },
               "/GET/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "GetRootApiPermissionTestTestMyApi8B2BE17AGETD0B1F4C3": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloLambda3D9C82D6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "MyApi49610EDF",
+              },
+              "/test-invoke-stage/GET/",
             ],
           ],
         },
@@ -218,44 +218,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "MyApiANYApiPermissionTestapigwMyApiCBFBC5B0ANYAD86D377": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "HelloLambda3D9C82D6",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "MyApi49610EDF",
-              },
-              "/test-invoke-stage/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "MyApiANYApiPermissionapigwMyApiCBFBC5B0ANY5BBED348": Object {
+    "MyApiANYApiPermissionTestMyApi8B2BE17AANY689FE066": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -290,6 +253,43 @@ Object {
                 "Ref": "MyApiDeploymentStageprodE1054AF0",
               },
               "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "MyApiANYApiPermissionTestTestMyApi8B2BE17AANYE4477AC0": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloLambda3D9C82D6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "MyApi49610EDF",
+              },
+              "/test-invoke-stage/*/",
             ],
           ],
         },
@@ -414,44 +414,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "MyApiproxyANYApiPermissionTestapigwMyApiCBFBC5B0ANYproxy6DC68FBB": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "HelloLambda3D9C82D6",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "MyApi49610EDF",
-              },
-              "/test-invoke-stage/*/*",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "MyApiproxyANYApiPermissionapigwMyApiCBFBC5B0ANYproxyB3375D73": Object {
+    "MyApiproxyANYApiPermissionTestMyApi8B2BE17AANYproxyD8FBCB14": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -486,6 +449,43 @@ Object {
                 "Ref": "MyApiDeploymentStageprodE1054AF0",
               },
               "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "MyApiproxyANYApiPermissionTestTestMyApi8B2BE17AANYproxy4A6D235F": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloLambda3D9C82D6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "MyApi49610EDF",
+              },
+              "/test-invoke-stage/*/*",
             ],
           ],
         },
@@ -578,7 +578,7 @@ Object {
 }
 `;
 
-exports[`ecs.json: ecs 1`] = `
+exports[`ecs.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -671,7 +671,7 @@ Object {
     },
     "ServiceSecurityGroupC96ED6A7": Object {
       "Properties": Object {
-        "GroupDescription": "ecs/Service/SecurityGroup",
+        "GroupDescription": "Test/Service/SecurityGroup",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -694,7 +694,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC",
+            "Value": "Test/VPC",
           },
         ],
       },
@@ -705,7 +705,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC",
+            "Value": "Test/VPC",
           },
         ],
       },
@@ -739,7 +739,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PrivateSubnet1",
+            "Value": "Test/VPC/PrivateSubnet1",
           },
         ],
         "VpcId": Object {
@@ -771,7 +771,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PrivateSubnet1",
+            "Value": "Test/VPC/PrivateSubnet1",
           },
         ],
         "VpcId": Object {
@@ -801,7 +801,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
       },
@@ -821,7 +821,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
       },
@@ -843,7 +843,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
         "VpcId": Object {
@@ -875,7 +875,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "ecs/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
         "VpcId": Object {
@@ -926,17 +926,17 @@ Object {
 }
 `;
 
-exports[`lambda-events.json: lambda-events 1`] = `
+exports[`lambda-events.json 1`] = `
 Object {
   "Outputs": Object {
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FEndpointC6202FF3": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FEndpointA8F0470B": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
           Array [
             "https://",
             Object {
-              "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+              "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
             },
             ".execute-api.",
             Object {
@@ -948,7 +948,7 @@ Object {
             },
             "/",
             Object {
-              "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentStageprod6A86C016",
+              "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeploymentStageprodA76DE31E",
             },
             "/",
           ],
@@ -964,7 +964,7 @@ Object {
     },
   },
   "Resources": Object {
-    "HelloWorldFunctionAllowInvokelambdaeventsMyTopic988FAB3E43035740": Object {
+    "HelloWorldFunctionAllowInvokeTestMyTopic06942AEA43E66FD3": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1008,7 +1008,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "HelloWorldFunctionDynamoDBEventSourcelambdaeventsTableF97C65E3DE5C745C": Object {
+    "HelloWorldFunctionDynamoDBEventSourceTestTable7FB9A4AF14EA3849": Object {
       "Properties": Object {
         "BatchSize": 100,
         "EventSourceArn": Object {
@@ -1134,27 +1134,27 @@ Object {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA": Object {
       "Properties": Object {
-        "Name": "lambdaeventsHelloWorldFunctionAB27BB65:ApiEventSourceA7A86A4F",
+        "Name": "TestHelloWorldFunctionE7E220B2:ApiEventSourceA7A86A4F",
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FAccountF7734F1E": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FAccount3FF2838C": Object {
       "DependsOn": Array [
-        "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+        "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
       ],
       "Properties": Object {
         "CloudWatchRoleArn": Object {
           "Fn::GetAtt": Array [
-            "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FCloudWatchRole495FDB9D",
+            "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FCloudWatchRole6F1F54C4",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ApiGateway::Account",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FCloudWatchRole495FDB9D": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FCloudWatchRole6F1F54C4": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1185,51 +1185,129 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentFF3F4A1Ac00dde791d2719be3e8ea69f9a61a5cd": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeployment1521BDCD1184383c2312dd2bd094c1c0b9e7069a": Object {
       "DependsOn": Array [
-        "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloGET04FBC7F6",
-        "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloPOST53F177B1",
-        "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloC30B3CD9",
+        "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloGETDEC3A558",
+        "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloPOST26F53363",
+        "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4Fhello434790F5",
       ],
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentStageprod6A86C016": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeploymentStageprodA76DE31E": Object {
       "DependsOn": Array [
-        "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FAccountF7734F1E",
+        "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FAccount3FF2838C",
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentFF3F4A1Ac00dde791d2719be3e8ea69f9a61a5cd",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeployment1521BDCD1184383c2312dd2bd094c1c0b9e7069a",
         },
         "RestApiId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
         },
         "StageName": "prod",
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloC30B3CD9": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4Fhello434790F5": Object {
       "Properties": Object {
         "ParentId": Object {
           "Fn::GetAtt": Array [
-            "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+            "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
             "RootResourceId",
           ],
         },
         "PathPart": "hello",
         "RestApiId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloGET04FBC7F6": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloGETApiPermissionTestTestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F2B53EF41GEThello55F7F880": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloWorldFunctionB2AB6E79",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
+              },
+              "/",
+              Object {
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeploymentStageprodA76DE31E",
+              },
+              "/GET/hello",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloGETApiPermissionTestTestTestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F2B53EF41GEThelloDA94F7CA": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloWorldFunctionB2AB6E79",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
+              },
+              "/test-invoke-stage/GET/hello",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloGETDEC3A558": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "GET",
@@ -1261,93 +1339,15 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloC30B3CD9",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4Fhello434790F5",
         },
         "RestApiId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloGETApiPermissionTestlambdaeventslambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F0AAEF724GEThello5EA12CF5": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "HelloWorldFunctionB2AB6E79",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
-              },
-              "/test-invoke-stage/GET/hello",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloGETApiPermissionlambdaeventslambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F0AAEF724GEThelloAC4AB5E4": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "HelloWorldFunctionB2AB6E79",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
-              },
-              "/",
-              Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentStageprod6A86C016",
-              },
-              "/GET/hello",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloPOST53F177B1": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloPOST26F53363": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "POST",
@@ -1379,15 +1379,15 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloC30B3CD9",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4Fhello434790F5",
         },
         "RestApiId": Object {
-          "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+          "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloPOSTApiPermissionTestlambdaeventslambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F0AAEF724POSThello991892DD": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloPOSTApiPermissionTestTestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F2B53EF41POSThelloAFA34AF4": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1415,16 +1415,20 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
               },
-              "/test-invoke-stage/POST/hello",
+              "/",
+              Object {
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FDeploymentStageprodA76DE31E",
+              },
+              "/POST/hello",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FhelloPOSTApiPermissionlambdaeventslambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F0AAEF724POSThello3501FACF": Object {
+    "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4FhelloPOSTApiPermissionTestTestTestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F2B53EF41POSThello70EA31F2": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1452,13 +1456,9 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4F12449C5F",
+                "Ref": "TestHelloWorldFunctionE7E220B2ApiEventSourceA7A86A4F040973BA",
               },
-              "/",
-              Object {
-                "Ref": "lambdaeventsHelloWorldFunctionAB27BB65ApiEventSourceA7A86A4FDeploymentStageprod6A86C016",
-              },
-              "/POST/hello",
+              "/test-invoke-stage/POST/hello",
             ],
           ],
         },
@@ -1496,7 +1496,7 @@ Object {
 }
 `;
 
-exports[`lambda-topic.json: lambda-topic 1`] = `
+exports[`lambda-topic.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -1506,7 +1506,7 @@ Object {
     },
   },
   "Resources": Object {
-    "LambdaAllowInvokelambdatopicTopic702108A3CE1309A3": Object {
+    "LambdaAllowInvokeTestTopic346FF53781B07C89": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1624,7 +1624,7 @@ Object {
 }
 `;
 
-exports[`pipeline.json: pipeline 1`] = `
+exports[`pipeline.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -1960,7 +1960,7 @@ Object {
     "PipelineArtifactsBucketEncryptionKeyAlias5C510EEE": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AliasName": "alias/codepipeline-pipelinepipeline22f2a91d",
+        "AliasName": "alias/codepipeline-testpipeline9942903c",
         "TargetKeyId": Object {
           "Fn::GetAtt": Array [
             "PipelineArtifactsBucketEncryptionKey01D58D69",
@@ -2735,7 +2735,7 @@ Object {
       },
       "Type": "AWS::CodeCommit::Repository",
     },
-    "RepopipelinePipeline22F2A91DEventRuleF314EE14": Object {
+    "RepoTestPipeline9942903CEventRule83B9BC8D": Object {
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -2831,7 +2831,7 @@ Object {
 }
 `;
 
-exports[`pure-cfn.json: pure-cfn 1`] = `
+exports[`pure-cfn.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -2885,7 +2885,7 @@ Object {
 }
 `;
 
-exports[`queue-kms.json: queue-kms 1`] = `
+exports[`queue-kms.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -2911,7 +2911,7 @@ Object {
     "MyQueueKey6C31ABF3": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "Description": "Created by queue-kms/MyQueue",
+        "Description": "Created by Test/MyQueue",
         "KeyPolicy": Object {
           "Statement": Array [
             Object {
@@ -2975,7 +2975,7 @@ Object {
 }
 `;
 
-exports[`vpc.json: vpc 1`] = `
+exports[`vpc.json 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -2994,7 +2994,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC",
+            "Value": "Test/VPC",
           },
         ],
       },
@@ -3005,7 +3005,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC",
+            "Value": "Test/VPC",
           },
         ],
       },
@@ -3039,7 +3039,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PrivateSubnet1",
+            "Value": "Test/VPC/PrivateSubnet1",
           },
         ],
         "VpcId": Object {
@@ -3071,7 +3071,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PrivateSubnet1",
+            "Value": "Test/VPC/PrivateSubnet1",
           },
         ],
         "VpcId": Object {
@@ -3097,7 +3097,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PrivateSubnet2",
+            "Value": "Test/VPC/PrivateSubnet2",
           },
         ],
         "VpcId": Object {
@@ -3140,7 +3140,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PrivateSubnet2",
+            "Value": "Test/VPC/PrivateSubnet2",
           },
         ],
         "VpcId": Object {
@@ -3170,7 +3170,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
       },
@@ -3190,7 +3190,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
       },
@@ -3212,7 +3212,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
         "VpcId": Object {
@@ -3244,7 +3244,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet1",
+            "Value": "Test/VPC/PublicSubnet1",
           },
         ],
         "VpcId": Object {
@@ -3274,7 +3274,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet2",
+            "Value": "Test/VPC/PublicSubnet2",
           },
         ],
       },
@@ -3294,7 +3294,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet2",
+            "Value": "Test/VPC/PublicSubnet2",
           },
         ],
       },
@@ -3305,7 +3305,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet2",
+            "Value": "Test/VPC/PublicSubnet2",
           },
         ],
         "VpcId": Object {
@@ -3348,7 +3348,7 @@ Object {
           },
           Object {
             "Key": "Name",
-            "Value": "vpc/VPC/PublicSubnet2",
+            "Value": "Test/VPC/PublicSubnet2",
           },
         ],
         "VpcId": Object {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,20 @@
+import { synthesize } from './util';
+
+test('invalid enum option raises an error', async () => {
+  // GIVEN
+  const template = {
+    Resources: {
+      Hello: {
+        Type: 'aws-cdk-lib.aws_sqs.Queue',
+        Properties: {
+          encryption: 'boom',
+        },
+      },
+    },
+  };
+
+  // THEN
+  await expect(synthesize(template)).rejects.toThrow(
+    'Could not find enum choice BOOM for enum type aws-cdk-lib.aws_sqs.QueueEncryption. Available options: [UNENCRYPTED, KMS_MANAGED, KMS]'
+  );
+});

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,4 +1,4 @@
-import { synthesize } from './util';
+import { Testing } from './util';
 
 test('invalid enum option raises an error', async () => {
   // GIVEN
@@ -14,7 +14,7 @@ test('invalid enum option raises an error', async () => {
   };
 
   // THEN
-  await expect(synthesize(template)).rejects.toThrow(
+  await expect(Testing.synth('test', template)).rejects.toThrow(
     'Could not find enum choice BOOM for enum type aws-cdk-lib.aws_sqs.QueueEncryption. Available options: [UNENCRYPTED, KMS_MANAGED, KMS]'
   );
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -14,7 +14,7 @@ test('invalid enum option raises an error', async () => {
   };
 
   // THEN
-  await expect(Testing.synth('test', template)).rejects.toThrow(
+  await expect(Testing.synth(template)).rejects.toThrow(
     'Could not find enum choice BOOM for enum type aws-cdk-lib.aws_sqs.QueueEncryption. Available options: [UNENCRYPTED, KMS_MANAGED, KMS]'
   );
 });

--- a/test/synth.test.ts
+++ b/test/synth.test.ts
@@ -1,41 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as cdk from 'aws-cdk-lib';
-import * as reflect from 'jsii-reflect';
-import {
-  DeclarativeStack,
-  loadTypeSystem,
-  readTemplate,
-  stackNameFromFileName,
-} from '../lib';
+import { readTemplate, stackNameFromFileName } from '../src';
+import { Testing } from './util';
 
 const dir = path.join(__dirname, '..', 'examples');
 
-let _cachedTS: reflect.TypeSystem;
-async function obtainTypeSystem() {
-  // Load the typesystem only once, it's quite expensive
-  if (!_cachedTS) {
-    _cachedTS = await loadTypeSystem(true);
-  }
-  return _cachedTS;
-}
-
 for (const templateFile of fs.readdirSync(dir)) {
   test(templateFile, async () => {
-    const workingDirectory = dir;
-    const template = await readTemplate(path.resolve(dir, templateFile));
-    const typeSystem = await obtainTypeSystem();
-
-    const app = new cdk.App();
     const stackName = stackNameFromFileName(templateFile);
+    const template = await readTemplate(path.resolve(dir, templateFile));
 
-    new DeclarativeStack(app, stackName, {
-      workingDirectory,
-      template,
-      typeSystem,
-    });
-
-    const output = app.synth().getStackByName(stackName);
+    const output = await Testing.synth(stackName, template);
     expect(output.template).toMatchSnapshot(stackName);
   });
 }

--- a/test/synth.test.ts
+++ b/test/synth.test.ts
@@ -1,16 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { readTemplate, stackNameFromFileName } from '../src';
+import { readTemplate } from '../src';
 import { Testing } from './util';
 
 const dir = path.join(__dirname, '..', 'examples');
 
 for (const templateFile of fs.readdirSync(dir)) {
   test(templateFile, async () => {
-    const stackName = stackNameFromFileName(templateFile);
     const template = await readTemplate(path.resolve(dir, templateFile));
 
-    const output = await Testing.synth(stackName, template);
-    expect(output.template).toMatchSnapshot(stackName);
+    const output = await Testing.synth(template);
+    expect(output.template).toMatchSnapshot();
   });
 }

--- a/test/synth.test.ts
+++ b/test/synth.test.ts
@@ -9,23 +9,13 @@ import {
   stackNameFromFileName,
 } from '../lib';
 
-const VALIDATE_ASSEMBLIES = true;
-
 const dir = path.join(__dirname, '..', 'examples');
-
-if (VALIDATE_ASSEMBLIES) {
-  // With validation loading all assemblies takes 10s on my machine.
-  // Without validation it's 600ms.
-  //
-  // Add a big margin for slower machines in case validation is enabled.
-  jest.setTimeout(60 * 1000);
-}
 
 let _cachedTS: reflect.TypeSystem;
 async function obtainTypeSystem() {
   // Load the typesystem only once, it's quite expensive
   if (!_cachedTS) {
-    _cachedTS = await loadTypeSystem(VALIDATE_ASSEMBLIES);
+    _cachedTS = await loadTypeSystem(true);
   }
   return _cachedTS;
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -14,18 +14,21 @@ async function obtainTypeSystem() {
   return _cachedTS;
 }
 
-export async function synthesize(template: any) {
-  const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
-  const stackName = 'test';
-  const typeSystem = await obtainTypeSystem();
+export class Testing {
+  public static async synth(stackName: string, template: any) {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
+    const typeSystem = await obtainTypeSystem();
 
-  const app = new cdk.App();
+    const app = new cdk.App();
 
-  new DeclarativeStack(app, stackName, {
-    workingDirectory,
-    template,
-    typeSystem,
-  });
+    new DeclarativeStack(app, stackName, {
+      workingDirectory,
+      template,
+      typeSystem,
+    });
 
-  return app.synth().getStackByName(stackName);
+    return app.synth().getStackByName(stackName);
+  }
+
+  private constructor() {}
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -15,8 +15,9 @@ async function obtainTypeSystem() {
 }
 
 export class Testing {
-  public static async synth(stackName: string, template: any) {
+  public static async synth(template: any) {
     const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
+    const stackName = 'Test';
     const typeSystem = await obtainTypeSystem();
 
     const app = new cdk.App();

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,31 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as fs from 'fs-extra';
+import * as reflect from 'jsii-reflect';
+import { DeclarativeStack, loadTypeSystem } from '../src';
+
+let _cachedTS: reflect.TypeSystem;
+async function obtainTypeSystem() {
+  // Load the typesystem only once, it's quite expensive
+  if (!_cachedTS) {
+    _cachedTS = await loadTypeSystem(true);
+  }
+  return _cachedTS;
+}
+
+export async function synthesize(template: any) {
+  const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
+  const stackName = 'test';
+  const typeSystem = await obtainTypeSystem();
+
+  const app = new cdk.App();
+
+  new DeclarativeStack(app, stackName, {
+    workingDirectory,
+    template,
+    typeSystem,
+  });
+
+  return app.synth().getStackByName(stackName);
+}


### PR DESCRIPTION
This PR refactors / unifies the parsing logic a little bit, and improves the testing utilities to make it easier to add future unit tests. To demonstrate changes to testing, second part, I added some error handling to check against invalid enum values in deCDK templates, and wrote a unit test for it in `errors.test.ts`.

I've separated most of the changes into smaller commits to make the PR easier to review.