### PR TITLE
fix: cannot create Constructs without props

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ When deCDK processes a template, it identifies these special resources and under
 
 When you build this module, it will produce a `cdk.schema.json` file at the root, which is referenced by the examples in the [`examples`](./examples) directory. This directory includes working examples of deCDK templates for various areas. We also snapshot-test those to ensure there are no unwanted regressions.
 
+### Running local code
+
+You can execute `decdk` using the current TypeScript code, without having to build the project. Provide this as your app argument to `cdk`:
+
+```sh
+cdk -a "ts-node src/decdk.ts template.json" synth
+```
+
 ## Design
 
 "Deconstruction" is the process of reflecting on the AWS Construct Library's type system and determining what would be the declarative interface for each API. This section describes how various elements in the library's type system are represented through the template format.

--- a/examples/lambda-layer.json
+++ b/examples/lambda-layer.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../cdk.schema.json",
+  "Resources": {
+    "AwsCliLayer": {
+      "Type": "aws-cdk-lib.lambda_layer_awscli.AwsCliLayer"
+    },
+    "Lambda": {
+      "Type": "aws-cdk-lib.aws_lambda.Function",
+      "Properties": {
+        "code": {
+          "fromInline": {
+            "code": "exports.handler = async function() { return 'SUCCESS'; }"
+          }
+        },
+        "runtime": "NODEJS_16_X",
+        "handler": "index.handler",
+        "layers": [
+          {
+            "Ref": "AwsCliLayer"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -1517,6 +1517,114 @@ Object {
 }
 `;
 
+exports[`lambda-layer.json 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "AwsCliLayerF44AAF94": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "1d3b5490cd99feddeb525a62c046988997469f2a765d0f12b43cff9d87a284fa.zip",
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "LambdaD247545B": Object {
+      "DependsOn": Array [
+        "LambdaServiceRoleA8ED4D3B",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "ZipFile": "exports.handler = async function() { return 'SUCCESS'; }",
+        },
+        "Handler": "index.handler",
+        "Layers": Array [
+          Object {
+            "Ref": "AwsCliLayerF44AAF94",
+          },
+        ],
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "LambdaServiceRoleA8ED4D3B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaServiceRoleA8ED4D3B": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`lambda-role-removed.json 1`] = `
 Object {
   "Parameters": Object {


### PR DESCRIPTION
Instead of relying on a naming convention for Props classes, we use the type
system to reflect the actual type. If the parameter is not present, we omit
deconstructing the properties.

Fixes #76