### PR TITLE
fix: falsy values do not get translated to properties

### DIFF
--- a/src/deconstruction.ts
+++ b/src/deconstruction.ts
@@ -306,7 +306,7 @@ export function deconstructInterface(options: DeconstructCommonOptions) {
   const out: any = {};
   for (const prop of typeRef.type.allProperties) {
     const propValue = value[prop.name];
-    if (!propValue) {
+    if (propValue === undefined) {
       if (!prop.optional) {
         throw new ValidationError(
           `Missing required property ${key}.${prop.name} in ${typeRef}`

--- a/test/properties.test.ts
+++ b/test/properties.test.ts
@@ -1,0 +1,20 @@
+import { Testing } from './util';
+
+test('can define boolean property as "false"', async () => {
+  // GIVEN
+  const template = await Testing.template({
+    Resources: {
+      Topic: {
+        Type: 'aws-cdk-lib.aws_sns.Topic',
+        Properties: {
+          fifo: false,
+        },
+      },
+    },
+  });
+
+  // THEN
+  template.hasResourceProperties('AWS::SNS::Topic', {
+    FifoTopic: false,
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import { DeclarativeStack, loadTypeSystem } from '../src';
@@ -16,19 +17,31 @@ async function obtainTypeSystem() {
 
 export class Testing {
   public static async synth(template: any) {
+    const { app, stack } = await this.prepare(template);
+
+    return app.synth().getStackByName(stack.stackName);
+  }
+
+  public static async template(template: any) {
+    const { stack } = await this.prepare(template);
+
+    return Template.fromStack(stack);
+  }
+
+  private static async prepare(template: any) {
     const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
     const stackName = 'Test';
     const typeSystem = await obtainTypeSystem();
 
     const app = new cdk.App();
 
-    new DeclarativeStack(app, stackName, {
+    const stack = new DeclarativeStack(app, stackName, {
       workingDirectory,
       template,
       typeSystem,
     });
 
-    return app.synth().getStackByName(stackName);
+    return { app, stack };
   }
 
   private constructor() {}


### PR DESCRIPTION
Fixes #8

This was reported as `false` Boolean value failing. Due to the nature of the
broken check, it prevented any falsy values from being translated correctly.

Change also includes additions to the test setup, adding support for fine grained
assertion tests.