### PR TITLE
chore: fix lambda examples fail with error `ENAMETOOLONG`

### DIFF
--- a/examples/apigw.json
+++ b/examples/apigw.json
@@ -5,7 +5,7 @@
       "Type": "aws-cdk-lib.aws_lambda.Function",
       "Properties": {
         "code": {
-          "fromAsset": { "path": "." }
+          "fromAsset": { "path": "examples/lambda-handler" }
         },
         "runtime": "PYTHON_3_6",
         "handler": "index.handler"

--- a/examples/lambda-events.json
+++ b/examples/lambda-events.json
@@ -20,7 +20,7 @@
         "handler": "app.hello_handler",
         "runtime": "PYTHON_3_6",
         "code": {
-          "fromAsset": { "path": "." }
+          "fromAsset": { "path": "examples/lambda-handler" }
         },
         "environment": {
           "Param": "f"
@@ -51,13 +51,15 @@
           }
         ]
       },
-      "Overrides": [{
-        "ChildConstructPath": "ServiceRole",
-        "Update": {
-          "Path": "Properties.Description",
-          "Value": "This value has been overridden"
+      "Overrides": [
+        {
+          "ChildConstructPath": "ServiceRole",
+          "Update": {
+            "Path": "Properties.Description",
+            "Value": "This value has been overridden"
+          }
         }
-      }]
+      ]
     }
   }
 }

--- a/examples/lambda-handler/index.js
+++ b/examples/lambda-handler/index.js
@@ -1,0 +1,3 @@
+exports.handler = async function() {
+    return 'SUCCESS';
+}

--- a/examples/lambda-role-removed.json
+++ b/examples/lambda-role-removed.json
@@ -4,15 +4,17 @@
     "Lambda": {
       "Type": "aws-cdk-lib.aws_lambda.Function",
       "Properties": {
-        "code": { "fromAsset": { "path": "." } },
+        "code": { "fromAsset": { "path": "examples/lambda-handler" } },
         "runtime": "NODEJS",
         "handler": "index.handler",
         "description": "This function has its service role removed, for demonstration purposes. You probably wouldn't do this to a real function"
       },
-      "Overrides": [{
-        "ChildConstructPath": "ServiceRole",
-        "RemoveResource": true
-      }]
+      "Overrides": [
+        {
+          "ChildConstructPath": "ServiceRole",
+          "RemoveResource": true
+        }
+      ]
     }
   }
 }

--- a/examples/lambda-topic.json
+++ b/examples/lambda-topic.json
@@ -7,7 +7,7 @@
     "Lambda": {
       "Type": "aws-cdk-lib.aws_lambda.Function",
       "Properties": {
-        "code": { "fromAsset": { "path": "." } },
+        "code": { "fromAsset": { "path": "examples/lambda-handler" } },
         "runtime": "NODEJS",
         "handler": "index.handler",
         "events": [

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -168,7 +168,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+          "S3Key": "41b1de375e679030ee7361874b689e99ab0657e9d274a8e6193d1513940a0c2f.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -1006,7 +1006,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+          "S3Key": "41b1de375e679030ee7361874b689e99ab0657e9d274a8e6193d1513940a0c2f.zip",
         },
         "Environment": Object {
           "Variables": Object {
@@ -1644,7 +1644,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+          "S3Key": "41b1de375e679030ee7361874b689e99ab0657e9d274a8e6193d1513940a0c2f.zip",
         },
         "Description": "This function has its service role removed, for demonstration purposes. You probably wouldn't do this to a real function",
         "Handler": "index.handler",
@@ -1724,7 +1724,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+          "S3Key": "41b1de375e679030ee7361874b689e99ab0657e9d274a8e6193d1513940a0c2f.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/test/synth.test.ts
+++ b/test/synth.test.ts
@@ -5,9 +5,17 @@ import { Testing } from './util';
 
 const dir = path.join(__dirname, '..', 'examples');
 
-for (const templateFile of fs.readdirSync(dir)) {
-  test(templateFile, async () => {
-    const template = await readTemplate(path.resolve(dir, templateFile));
+const isTemplateFile = (dirent: fs.Dirent): boolean =>
+  dirent.isFile() &&
+  (dirent.name.endsWith('.json') || dirent.name.endsWith('.yaml'));
+
+const examples = fs
+  .readdirSync(dir, { withFileTypes: true })
+  .filter(isTemplateFile);
+
+for (const templateFile of examples) {
+  test(templateFile.name, async () => {
+    const template = await readTemplate(path.resolve(dir, templateFile.name));
 
     const output = await Testing.synth(template);
     expect(output.template).toMatchSnapshot();

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,8 +1,5 @@
-import * as os from 'os';
-import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import { DeclarativeStack, loadTypeSystem } from '../src';
 
@@ -29,14 +26,12 @@ export class Testing {
   }
 
   private static async prepare(template: any) {
-    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'decdk-'));
     const stackName = 'Test';
     const typeSystem = await obtainTypeSystem();
 
     const app = new cdk.App();
 
     const stack = new DeclarativeStack(app, stackName, {
-      workingDirectory,
       template,
       typeSystem,
     });


### PR DESCRIPTION
Resolves #164 

Note this changes removes running (some) tests in a temporary working dir. Changing the working directory breaks assumptions about the CWD for file paths. There was no apparent reason why this was introduced in the first place in #110.

There is an open question about how we want to deal with relative file paths. The two options are:
- relative to the CWD
- relative to the template

There is a comment in [deconstruction.ts](https://github.com/cdklabs/decdk/blob/ee07573d61a470288890d14d739dfb88092b51b8/src/deconstruction.ts#L853-L854) that indicates it should be relative to the template file. However the current implementation in [decdk.ts](https://github.com/cdklabs/decdk/blob/145238a53f1f9f8db5c1808500e6bac4c8a0d4a1/src/decdk.ts#L25) does NOT do that (note the missing `workingDirectory` prop).

I've left it at the current implementation (relative to the CWD) for now, which I think is also closer to how imperative CDK behaves. In future the most transparent might be a command line option. Related #200 