### PR TITLE
feat: added a template parser

### DIFF
--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -1,0 +1,9 @@
+# Template parser
+
+This folder contains the logic to parse declarative CDK templates. It transforms the input file into an abstract 
+syntax tree, with all the necessary annotations, that can be used later for evaluation.
+
+This code was copied and adapted from [cfnengine], by Rico Huijbers.
+
+
+[cfnengine]: https://github.com/rix0rrr/cfngine

--- a/src/parser/private/cfn-yaml.ts
+++ b/src/parser/private/cfn-yaml.ts
@@ -1,0 +1,50 @@
+import * as yaml from 'yaml';
+import * as yaml_cst from 'yaml/parse-cst';
+import * as yaml_types from 'yaml/types';
+
+const shortForms: yaml_types.Schema.CustomTag[] = [
+  'Base64',
+  'Cidr',
+  'FindInMap',
+  'GetAZs',
+  'ImportValue',
+  'Join',
+  'Sub',
+  'Select',
+  'Split',
+  'Transform',
+  'And',
+  'Equals',
+  'If',
+  'Not',
+  'Or',
+  'GetAtt',
+]
+  .map((name) => intrinsicTag(name, true))
+  .concat(intrinsicTag('Ref', false), intrinsicTag('Condition', false));
+
+export function parseCfnYaml(text: string): any {
+  return yaml.parse(text, {
+    customTags: shortForms,
+    schema: 'core',
+  });
+}
+
+function intrinsicTag(
+  intrinsicName: string,
+  addFnPrefix: boolean
+): yaml_types.Schema.CustomTag {
+  return {
+    identify(value: any) {
+      return typeof value === 'string';
+    },
+    tag: `!${intrinsicName}`,
+    resolve: (_doc: yaml.Document, cstNode: yaml_cst.CST.Node) => {
+      const ret: any = {};
+      ret[addFnPrefix ? `Fn::${intrinsicName}` : intrinsicName] =
+        // the +1 is to account for the ! the short form begins with
+        parseCfnYaml(cstNode.toString().substring(intrinsicName.length + 1));
+      return ret;
+    },
+  };
+}

--- a/src/parser/private/everything-obj.ts
+++ b/src/parser/private/everything-obj.ts
@@ -1,0 +1,10 @@
+export function proxiedGetter(handler: (propName: string) => string) {
+  return new Proxy(
+    {},
+    {
+      get(_target, name, _receiver) {
+        return handler(String(name));
+      },
+    }
+  );
+}

--- a/src/parser/private/sub.ts
+++ b/src/parser/private/sub.ts
@@ -1,0 +1,58 @@
+export function analyzeSubPattern(pattern: string): SubFragment[] {
+  const ret: SubFragment[] = [];
+  let start = 0;
+
+  let ph0 = pattern.indexOf('${', start);
+  while (ph0 > -1) {
+    if (pattern[ph0 + 2] === '!') {
+      // "${!" means "don't actually substitute"
+      ret.push({ type: 'literal', content: pattern.substring(start, ph0 + 3) });
+      start = ph0 + 3;
+      ph0 = pattern.indexOf('${', start);
+      continue;
+    }
+
+    const ph1 = pattern.indexOf('}', ph0 + 2);
+    if (ph1 === -1) {
+      break;
+    }
+    const placeholder = pattern.substring(ph0 + 2, ph1);
+
+    if (ph0 > start) {
+      ret.push({ type: 'literal', content: pattern.substring(start, ph0) });
+    }
+    if (placeholder.includes('.')) {
+      const logicalId = placeholder.split('.')[0];
+      // Because split('.', 2) doesn't do what you think it does
+      const attr = placeholder.substring(logicalId.length + 1);
+
+      ret.push({ type: 'getatt', logicalId: logicalId!, attr: attr! });
+    } else {
+      ret.push({ type: 'ref', logicalId: placeholder });
+    }
+
+    start = ph1 + 1;
+    ph0 = pattern.indexOf('${', start);
+  }
+
+  if (start < pattern.length) {
+    ret.push({ type: 'literal', content: pattern.substring(start) });
+  }
+
+  return ret;
+}
+
+export type SubFragment =
+  | { readonly type: 'literal'; readonly content: string }
+  | { readonly type: 'ref'; readonly logicalId: string }
+  | {
+      readonly type: 'getatt';
+      readonly logicalId: string;
+      readonly attr: string;
+    };
+
+export function isNonLiteral(
+  x: SubFragment
+): x is Extract<SubFragment, { type: 'ref' | 'getatt' }> {
+  return x.type !== 'literal';
+}

--- a/src/parser/private/toposort.ts
+++ b/src/parser/private/toposort.ts
@@ -1,0 +1,269 @@
+export class DependencyGraph<A> {
+  public readonly keys = new Set(Object.keys(this.nodes));
+
+  constructor(
+    private readonly nodes: Record<string, A>,
+    private readonly _dependencies: Map<string, Set<string>>
+  ) {
+    // Restrict dependencies to only keys in nodes
+    for (const [name, deps] of this._dependencies.entries()) {
+      if (name in nodes) {
+        this._dependencies.set(name, intersect(deps, this.keys));
+      }
+    }
+  }
+
+  /**
+   * Return a single node in the graph
+   */
+  public get(key: string): A {
+    const ret = this.nodes[key];
+    if (ret === undefined) {
+      throw new Error(`No such key: ${key}`);
+    }
+    return ret;
+  }
+
+  /**
+   * Return a copy of the graph, restricted to only the nodes in the list
+   */
+  public restrict(keys: string[]) {
+    const nodes = Object.fromEntries(
+      Object.entries(this.nodes).filter(([k, _]) => keys.includes(k))
+    );
+    return new DependencyGraph(nodes, this.copyDependencies());
+  }
+
+  /**
+   * The node is that are direct dependencies of the given node
+   */
+  public directDependencies(key: string): string[] {
+    return Array.from(this.dependencies.get(key) ?? []);
+  }
+
+  /**
+   * The node is that are direct dependents on the given node
+   */
+  public directDependents(key: string): string[] {
+    return Array.from(this.dependencies.entries())
+      .filter(([_, xs]) => xs.has(key))
+      .map(([k, _]) => k);
+  }
+
+  /**
+   * All nodes that are dependencies of this node, and this node itself
+   */
+  public upstream(key: string) {
+    this.closure(key, (k) => this.directDependencies(k));
+  }
+
+  /**
+   * All nodes that are dependents of this node, and this node itself
+   */
+  public downstream(key: string) {
+    return this.closure(key, (k) => this.directDependents(k));
+  }
+
+  /**
+   * Turn the graph into a queue that can be consumed in dependency order
+   */
+  public topoQueue(): TopoQueue<A> {
+    return new TopoQueue(this);
+  }
+
+  /**
+   * Whether the given node has dependencies
+   */
+  public hasDependencies(key: string) {
+    return !!this._dependencies.get(key)?.size;
+  }
+
+  /**
+   * Remove a node from the graph
+   */
+  public removeNode(key: string) {
+    delete this.nodes[key];
+    this._dependencies.delete(key);
+    for (const sets of this._dependencies.values()) {
+      sets.delete(key);
+    }
+  }
+
+  /**
+   * Merge two graphs, return a new graph
+   */
+  public merge<B>(other: DependencyGraph<B>): DependencyGraph<A | B> {
+    const nodes = { ...this.nodes, ...other.nodes };
+    const deps = this.copyDependencies();
+    for (const [k, xs] of other.copyDependencies().entries()) {
+      deps.set(
+        k,
+        new Set(Array.from(deps.get(k) ?? []).concat(Array.from(xs)))
+      );
+    }
+    return new DependencyGraph(nodes, deps);
+  }
+
+  /**
+   * Return a copy of the graph
+   */
+  public copy() {
+    return new DependencyGraph({ ...this.nodes }, this.copyDependencies());
+  }
+
+  /**
+   * Access the dependency map
+   */
+  public get dependencies(): ReadonlyMap<string, ReadonlySet<string>> {
+    return this._dependencies;
+  }
+
+  private copyDependencies() {
+    return new Map(
+      Array.from(this._dependencies.entries()).map(
+        ([k, v]) => [k, new Set(v)] as const
+      )
+    );
+  }
+
+  private closure(startingKey: string, mapping: (key: string) => string[]) {
+    const found = new Set<string>();
+    const queue = [startingKey];
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      if (found.has(next)) {
+        continue;
+      }
+
+      found.add(next);
+      queue.push(...mapping(next));
+    }
+    return this.restrict(Array.from(found));
+  }
+}
+
+/**
+ * A queue that will deliver its values in topologically sorted order
+ */
+export class TopoQueue<A> {
+  private readonly blocked: Set<string>;
+  private readonly available = new Array<string>();
+  private readonly originalGraph: DependencyGraph<A>;
+  private readonly currentGraph: DependencyGraph<A>;
+
+  constructor(graph: DependencyGraph<A>) {
+    this.originalGraph = graph;
+    this.currentGraph = graph.copy();
+    this.blocked = new Set(graph.keys);
+    this.determineAvailable();
+  }
+
+  public isEmpty() {
+    return this.blocked.size + this.available.length === 0;
+  }
+
+  public take(): QueueElement<A> {
+    const identifier = this.available.shift();
+    if (!identifier) {
+      throw new Error("Cannot 'take', queue is empty");
+    }
+
+    return {
+      identifier,
+      element: this.originalGraph.get(identifier),
+      remove: () => {
+        this.advance(identifier);
+      },
+    };
+  }
+
+  public withNext<B>(block: (identifier: string, element: A) => B): B {
+    const one = this.take();
+    const ret = block(one.identifier, one.element);
+    one.remove();
+    return ret;
+  }
+
+  public peek(): PeekElements<A> {
+    const elements = this.available.map(
+      (key) => [key, this.originalGraph.get(key)] as const
+    );
+    return {
+      elements,
+      skip: () => {
+        this.available.splice(0, this.available.length);
+        for (const el of elements) {
+          this.advance(el[0]);
+        }
+      },
+    };
+  }
+
+  private advance(key: string) {
+    this.currentGraph.removeNode(key);
+    this.determineAvailable();
+  }
+
+  private determineAvailable() {
+    const avail = Array.from(this.blocked).filter(
+      (key) => !this.currentGraph.hasDependencies(key)
+    );
+
+    for (const x of avail) {
+      this.blocked.delete(x);
+    }
+    this.available.push(...avail);
+
+    if (this.blocked.size > 0 && this.available.length === 0) {
+      const cycle = findCycle(this.currentGraph.dependencies);
+      throw new Error(`Dependency cycle in graph: ${cycle.join(' => ')}`);
+    }
+  }
+}
+
+export interface QueueElement<A> {
+  readonly identifier: string;
+  readonly element: A;
+
+  remove(): void;
+}
+
+export interface PeekElements<A> {
+  readonly elements: Array<readonly [string, A]>;
+
+  skip(): void;
+}
+
+/**
+ * Find cycles in a graph
+ *
+ * Not the fastest, but effective and should be rare
+ */
+function findCycle(deps: ReadonlyMap<string, ReadonlySet<string>>): string[] {
+  for (const node of deps.keys()) {
+    const cycle = recurse(node, [node]);
+    if (cycle) {
+      return cycle;
+    }
+  }
+  throw new Error('No cycle found. Assertion failure!');
+
+  function recurse(node: string, path: string[]): string[] | undefined {
+    for (const dep of deps.get(node) ?? []) {
+      if (dep === path[0]) {
+        return [...path, dep];
+      }
+
+      const cycle = recurse(dep, [...path, dep]);
+      if (cycle) {
+        return cycle;
+      }
+    }
+
+    return undefined;
+  }
+}
+
+function intersect<A>(xs: Set<A>, ys: Set<A>) {
+  return new Set(Array.from(xs).filter((x) => ys.has(x)));
+}

--- a/src/parser/private/types.ts
+++ b/src/parser/private/types.ts
@@ -1,0 +1,103 @@
+import { RetentionPolicy } from '../template';
+
+export function parseNumber(asString: string | number) {
+  const asNumber = parseInt(`${asString}`, 10);
+  if (`${asNumber}` !== `${asString}`) {
+    throw new Error(`Not a number: ${asString}`);
+  }
+  return { asString: `${asNumber}`, asNumber };
+}
+
+export function assertString(x: unknown): string {
+  if (typeof x === 'number') {
+    return `${x}`;
+  }
+  if (typeof x === 'string') {
+    return x;
+  }
+  throw new Error(`Expected string, got: ${JSON.stringify(x)}`);
+}
+
+export function assertNumber(x: unknown): number {
+  if (typeof x === 'number') {
+    return x;
+  }
+  if (typeof x === 'string') {
+    return parseNumber(x).asNumber;
+  }
+  throw new Error(`Expected number, got: ${JSON.stringify(x)}`);
+}
+
+export function assertList(x: unknown, lengths?: number[]): unknown[] {
+  if (!Array.isArray(x)) {
+    throw new Error(`Expected list, got: ${JSON.stringify(x)}`);
+  }
+  if (lengths && !lengths.includes(x.length)) {
+    throw new Error(`Expected list of length ${lengths}, got ${x.length}`);
+  }
+  return x;
+}
+
+export function assertBoolean(x: unknown): boolean {
+  if (typeof x !== 'boolean') {
+    throw new Error(`Expected boolean, got: ${JSON.stringify(x)}`);
+  }
+  return x;
+}
+
+export function assertObject(x: unknown): Record<string, unknown> {
+  if (typeof x !== 'object' || x == null || Array.isArray(x)) {
+    throw new Error(`Expected object, got: ${JSON.stringify(x)}`);
+  }
+  return x as any;
+}
+
+export function assertField<A extends object, K extends keyof A>(
+  xs: A,
+  fieldName: K
+): unknown {
+  if (!(fieldName in xs)) {
+    throw new Error(`Expected field named '${String(fieldName)}'`);
+  }
+  return xs[fieldName];
+}
+
+export function assertStringOrList(x: unknown): string[] {
+  if (typeof x === 'string') {
+    return [x];
+  }
+  if (Array.isArray(x)) {
+    const nonStrings = x.filter((y) => typeof y !== 'string');
+    if (nonStrings.length > 0) {
+      throw new Error(`Expected all strings in array, found: ${nonStrings}`);
+    }
+    return x as string[];
+  }
+  throw new Error(
+    `Expected string or list of strings, got: ${JSON.stringify(x)}`
+  );
+}
+
+export function parseRetentionPolicy(x: unknown): RetentionPolicy {
+  switch (x) {
+    case 'Delete':
+      return 'Delete';
+    case 'Retain':
+      return 'Retain';
+    case 'Snapshot':
+      return 'Snapshot';
+  }
+
+  throw new Error(
+    `Expected one of Delete|Retain|Snapshot, got: ${JSON.stringify(x)}`
+  );
+}
+
+export function mapFromObject<A>(
+  xs: unknown,
+  fn: (x: unknown) => A
+): Map<string, A> {
+  return new Map(
+    Object.entries(assertObject(xs)).map(([k, v]) => [k, fn(v as any)])
+  );
+}

--- a/src/parser/private/util.ts
+++ b/src/parser/private/util.ts
@@ -1,0 +1,9 @@
+export function mkDict<A>(
+  xs: ReadonlyArray<readonly [string, A]>
+): Record<string, A> {
+  const ret: Record<string, A> = {};
+  for (const [k, v] of xs) {
+    ret[k] = v;
+  }
+  return ret;
+}

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -1,0 +1,127 @@
+export namespace schema {
+  export interface Template {
+    readonly Resources?: Record<string, Resource>;
+    readonly AWSTemplateFormatVersion?: string;
+    readonly Description?: string;
+    readonly Metadata?: Record<any, any>;
+    readonly Parameters?: Record<string, Parameter>;
+    readonly Rules?: Record<string, Rule>;
+    readonly Mappings?: Record<string, Mapping>;
+    readonly Conditions?: Record<string, Condition>;
+    readonly Transform?: string[];
+    readonly Outputs?: Record<string, Output>;
+  }
+
+  export interface Resource {
+    readonly Type: string;
+    readonly Properties?: Record<string, CfnValue<any>>;
+    readonly Condition?: string;
+    readonly DependsOn?: string | string[];
+    readonly DeletionPolicy?: 'Retain' | 'Delete' | 'Snapshot';
+    readonly UpdateReplacePolicy?: 'Retain' | 'Delete' | 'Snapshot';
+    readonly Metadata?: Record<string, any>;
+    readonly CreationPolicy?: CreationPolicy;
+    readonly UpdatePolicy?: UpdatePolicy;
+  }
+
+  export interface CreationPolicy {
+    readonly AutoScalingCreationPolicy?: AutoScalingCreationPolicy;
+    readonly ResourceSignal?: ResourceSignal;
+  }
+
+  export interface UpdatePolicy {
+    // TODO
+    [key: string]: any;
+  }
+
+  export interface AutoScalingCreationPolicy {
+    readonly MinSuccessfulInstancesPercent: number;
+  }
+
+  export interface ResourceSignal {
+    readonly Count: number;
+    readonly Timeout: string;
+  }
+
+  export interface Parameter {
+    readonly Type: string;
+    readonly Description?: string;
+    readonly Default?: any;
+    readonly AllowedValues?: any[];
+    readonly AllowedPattern?: string;
+    readonly ConstraintDescription?: string;
+    readonly MaxLength?: number;
+    readonly MinLength?: number;
+    readonly MinValue?: number;
+    readonly MaxValue?: number;
+    readonly NoEcho?: boolean;
+  }
+
+  export interface Rule {}
+
+  export interface Output {
+    readonly Description?: string;
+    readonly Value: CfnValue<string>;
+    readonly Export?: {
+      readonly Name: CfnValue<string>;
+    };
+    readonly Condition?: string;
+  }
+
+  export type Mapping = Record<string, any>;
+
+  export type CfnValue<A> = A | Intrinsic;
+
+  export type Intrinsic =
+    | Ref
+    | FnBase64
+    | FnCidr
+    | FnFindInMap
+    | FnGetAZs
+    | FnGetAtt
+    | FnIf
+    | FnImportValue
+    | FnJoin
+    | FnSelect
+    | FnSplit
+    | FnSub;
+
+  export type Ref = { Ref: string };
+  export type FnBase64 = { 'Fn::Base64': CfnValue<string> };
+  export type FnCidr = {
+    'Fn::Cidr': [string | FnSelect | Ref, number, number];
+  };
+  export type FnFindInMap = {
+    'Fn::FindInMap': [CfnValue<string>, CfnValue<string>, CfnValue<string>];
+  };
+  export type FnGetAZs = { 'Fn::GetAZs': string | Ref };
+  export type FnGetAtt = { 'Fn::GetAtt': [string, string | Ref] };
+  export type FnIf = { 'Fn::If': [string, CfnValue<any>, CfnValue<any>] };
+  export type FnImportValue = { 'Fn::ImportValue': CfnValue<string> };
+  export type FnJoin = {
+    'Fn::Join': [string, CfnValue<Array<CfnValue<string>>>];
+  };
+  export type FnSelect = { 'Fn::Select': [CfnValue<number>, CfnValue<string>] };
+  export type FnSplit = { 'Fn::Split': [string, CfnValue<string>] };
+  export type FnSub = {
+    'Fn::Sub': string | [string, Record<string, CfnValue<string>>];
+  };
+
+  export type FnTransform = {
+    'Fn::Transform': {
+      readonly Name: string;
+      readonly Parameters: Record<string, CfnValue<any>>;
+    };
+  };
+
+  export type Condition = FnEquals | FnAnd | FnNot | FnOr;
+
+  export type ConditionValue<A> = A | FnFindInMap | Ref;
+
+  export type FnAnd = { 'Fn::And': Condition[] };
+  export type FnOr = { 'Fn::Or': Condition[] };
+  export type FnNot = { 'Fn::Not': [Condition] };
+  export type FnEquals = {
+    'Fn::Equals': [ConditionValue<string>, ConditionValue<string>];
+  };
+}

--- a/src/parser/template/enums.ts
+++ b/src/parser/template/enums.ts
@@ -1,0 +1,1 @@
+export type RetentionPolicy = 'Retain' | 'Delete' | 'Snapshot';

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -1,0 +1,361 @@
+import { analyzeSubPattern, SubFragment } from '../private/sub';
+import {
+  assertField,
+  assertList,
+  assertObject,
+  assertString,
+} from '../private/types';
+
+export type TemplateExpression =
+  | StringLiteral
+  | ObjectLiteral
+  | ArrayLiteral
+  | IntrinsicExpression;
+
+export interface StringLiteral {
+  readonly type: 'string';
+  readonly value: string;
+}
+
+export interface ObjectLiteral {
+  readonly type: 'object';
+  readonly fields: Record<string, TemplateExpression>;
+}
+
+export interface ArrayLiteral {
+  readonly type: 'array';
+  readonly array: TemplateExpression[];
+}
+
+export type IntrinsicExpression =
+  | RefIntrinsic
+  | GetAttIntrinsic
+  | Base64Intrinsic
+  | CidrIntrinsic
+  | FindInMapIntrinsic
+  | GetAZsIntrinsic
+  | IfIntrinsic
+  | ImportValueIntrinsic
+  | JoinIntrinsic
+  | SelectIntrinsic
+  | SplitIntrinsic
+  | SubIntrinsic
+  | TransformIntrinsic
+  | AndIntrinsic
+  | OrIntrinsic
+  | NotIntrinsic
+  | EqualsIntrinsic;
+
+export interface RefIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'ref';
+  readonly logicalId: string;
+}
+
+export interface GetAttIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'getAtt';
+  readonly logicalId: string;
+  readonly attribute: TemplateExpression;
+}
+
+export interface Base64Intrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'base64';
+  readonly expression: TemplateExpression;
+}
+
+export interface CidrIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'cidr';
+  readonly ipBlock: TemplateExpression;
+  readonly count: TemplateExpression;
+  readonly netMask: TemplateExpression;
+}
+
+export interface FindInMapIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'findInMap';
+  readonly mappingName: string;
+  readonly key1: TemplateExpression;
+  readonly key2: TemplateExpression;
+}
+
+export interface GetAZsIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'getAzs';
+  readonly region: TemplateExpression;
+}
+
+export interface IfIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'if';
+  readonly conditionName: string;
+  readonly then: TemplateExpression;
+  readonly else: TemplateExpression;
+}
+
+export interface ImportValueIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'importValue';
+  readonly export: TemplateExpression;
+}
+
+export interface JoinIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'join';
+  readonly separator: string;
+  readonly array: TemplateExpression;
+}
+
+export interface SelectIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'select';
+  readonly index: TemplateExpression;
+  readonly array: TemplateExpression;
+}
+
+export interface SplitIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'split';
+  readonly separator: string;
+  readonly value: TemplateExpression;
+}
+
+export interface SubIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'sub';
+  readonly fragments: SubFragment[];
+  readonly additionalContext: Record<string, TemplateExpression>;
+}
+
+export interface TransformIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'transform';
+  readonly transformName: string;
+  readonly parameters: Record<string, TemplateExpression>;
+}
+
+export interface AndIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'and';
+  readonly operands: TemplateExpression[];
+}
+
+export interface OrIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'or';
+  readonly operands: TemplateExpression[];
+}
+
+export interface NotIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'not';
+  readonly operand: TemplateExpression;
+}
+
+export interface EqualsIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'equals';
+  readonly value1: TemplateExpression;
+  readonly value2: TemplateExpression;
+}
+
+export function parseExpression(x: unknown): TemplateExpression {
+  if (typeof x === 'string') {
+    return { type: 'string', value: x };
+  }
+  // There are no such things as numbers or booleans in CloudFormation.
+  if (typeof x === 'number' || typeof x === 'boolean') {
+    return { type: 'string', value: `${x}` };
+  }
+  if (Array.isArray(x)) {
+    return { type: 'array', array: x.map(parseExpression) };
+  }
+
+  const INTRINSIC_TABLE: Record<string, (x: unknown) => IntrinsicExpression> = {
+    Ref: (value) => ({
+      type: 'intrinsic',
+      fn: 'ref',
+      logicalId: assertString(value),
+    }),
+    'Fn::GetAtt': (value) => {
+      const xs = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'getAtt',
+        logicalId: assertString(xs[0]),
+        attribute: parseExpression(xs[1]),
+      };
+    },
+    'Fn::Base64': (value) => ({
+      type: 'intrinsic',
+      fn: 'base64',
+      expression: parseExpression(value),
+    }),
+    'Fn::Cidr': (value) => {
+      const xs = assertList(value, [3]);
+      return {
+        type: 'intrinsic',
+        fn: 'cidr',
+        ipBlock: parseExpression(xs[0]),
+        count: parseExpression(xs[1]),
+        netMask: parseExpression(xs[2]),
+      };
+    },
+    'Fn::FindInMap': (value) => {
+      const xs = assertList(value, [3]);
+      return {
+        type: 'intrinsic',
+        fn: 'findInMap',
+        mappingName: assertString(xs[0]),
+        key1: parseExpression(xs[1]),
+        key2: parseExpression(xs[2]),
+      };
+    },
+    'Fn::GetAZs': (value) => ({
+      type: 'intrinsic',
+      fn: 'getAzs',
+      region: parseExpression(value),
+    }),
+    'Fn::If': (value) => {
+      const xs = assertList(value, [3]);
+      return {
+        type: 'intrinsic',
+        fn: 'if',
+        conditionName: assertString(xs[0]),
+        then: parseExpression(xs[1]),
+        else: parseExpression(xs[2]),
+      };
+    },
+    'Fn::ImportValue': (value) => ({
+      type: 'intrinsic',
+      fn: 'importValue',
+      export: parseExpression(value),
+    }),
+    'Fn::Join': (value) => {
+      const xs = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'join',
+        separator: assertString(xs[0]),
+        array: parseExpression(xs[1]),
+      };
+    },
+    'Fn::Select': (value) => {
+      const xs = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'select',
+        index: parseExpression(xs[0]),
+        array: parseExpression(xs[1]),
+      };
+    },
+    'Fn::Split': (value) => {
+      const xs = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'split',
+        separator: assertString(xs[0]),
+        value: parseExpression(xs[1]),
+      };
+    },
+    'Fn::Sub': (value) => {
+      let pattern: string;
+      let context: Record<string, TemplateExpression>;
+      if (typeof value === 'string') {
+        pattern = value;
+        context = {};
+      } else if (Array.isArray(value)) {
+        const xs = assertList(value);
+        pattern = assertString(xs[0]);
+        context = parseObject(xs[1]);
+      } else {
+        throw new Error(`Argument to {Fn::Sub} is of wrong type`);
+      }
+
+      const fragments = analyzeSubPattern(pattern);
+      return {
+        type: 'intrinsic',
+        fn: 'sub',
+        fragments,
+        additionalContext: context,
+      };
+    },
+    'Fn::Transform': (value) => {
+      const fields = assertObject(value);
+
+      const parameters = parseObject(assertField(fields, 'Parameters'));
+      return {
+        type: 'intrinsic',
+        fn: 'transform',
+        transformName: assertString(assertField(fields, 'Name')),
+        parameters,
+      };
+    },
+    'Fn::And': (value) => {
+      return {
+        type: 'intrinsic',
+        fn: 'and',
+        operands: assertList(value).map(parseExpression),
+      };
+    },
+    'Fn::Or': (value) => {
+      return {
+        type: 'intrinsic',
+        fn: 'or',
+        operands: assertList(value).map(parseExpression),
+      };
+    },
+    'Fn::Not': (value) => {
+      return {
+        type: 'intrinsic',
+        fn: 'not',
+        operand: parseExpression(value),
+      };
+    },
+    'Fn::Equals': (value) => {
+      const [x1, x2] = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'equals',
+        value1: parseExpression(x1),
+        value2: parseExpression(x2),
+      };
+    },
+  };
+
+  if (typeof x === 'object' && x) {
+    const keys = Object.keys(x);
+    if (keys.length === 1 && INTRINSIC_TABLE[keys[0]]) {
+      return INTRINSIC_TABLE[keys[0]]((x as any)[keys[0]]);
+    }
+    return {
+      type: 'object',
+      fields: parseObject(x),
+    };
+  }
+
+  throw new Error(`Unable to parse: ${JSON.stringify(x)}`);
+}
+
+export function parseObject(x: unknown) {
+  if (x === undefined) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(assertObject(x)).map(([k, v]) => [k, parseExpression(v)])
+  );
+}
+
+export function ifField<A extends object, K extends keyof A, B>(
+  xs: A,
+  k: K,
+  fn: (x: NonNullable<A[K]>) => B
+): B | undefined {
+  if (xs[k] != null) {
+    return fn(xs[k] as any);
+  }
+  return undefined;
+}

--- a/src/parser/template/index.ts
+++ b/src/parser/template/index.ts
@@ -1,0 +1,5 @@
+export * from './enums';
+export * from './expression';
+export * from './parameters';
+export * from './resource';
+export * from './template';

--- a/src/parser/template/mappings.ts
+++ b/src/parser/template/mappings.ts
@@ -1,0 +1,7 @@
+import { assertStringOrList, mapFromObject } from '../private/types';
+
+export type TemplateMapping = Map<string, Map<string, string | string[]>>;
+
+export function parseMapping(xs: unknown): TemplateMapping {
+  return mapFromObject(xs, (m) => mapFromObject(m, assertStringOrList));
+}

--- a/src/parser/template/output.ts
+++ b/src/parser/template/output.ts
@@ -1,0 +1,21 @@
+import { assertField, assertString } from '../private/types';
+import { schema } from '../schema';
+import { ifField, parseExpression, TemplateExpression } from './expression';
+
+export interface TemplateOutput {
+  readonly description?: string;
+  readonly value: TemplateExpression;
+  readonly exportName?: TemplateExpression;
+  readonly conditionName?: string;
+}
+
+export function parseOutput(x: schema.Output): TemplateOutput {
+  return {
+    value: parseExpression(x.Value),
+    conditionName: ifField(x, 'Condition', assertString),
+    description: ifField(x, 'Description', assertString),
+    exportName: ifField(x, 'Export', (e) =>
+      parseExpression(assertField(e, 'Name'))
+    ),
+  };
+}

--- a/src/parser/template/parameters.ts
+++ b/src/parser/template/parameters.ts
@@ -1,0 +1,155 @@
+import { parseNumber } from '../private/types';
+import { schema } from '../schema';
+
+export type ContextValue = string | string[] | symbol;
+
+export class TemplateParameters {
+  constructor(private readonly parameters: Record<string, schema.Parameter>) {}
+
+  public get required(): Record<string, schema.Parameter> {
+    return Object.fromEntries(
+      Object.entries(this.parameters).filter(
+        ([_, param]) => param.Default == null
+      )
+    );
+  }
+
+  public has(name: string) {
+    return !!this.parameters[name];
+  }
+
+  public parse(name: string, value: string) {
+    const param = this.parameters[name];
+    if (!param) {
+      throw new Error(`Unknown parameter: ${name}`);
+    }
+    return parseParamValue(name, param, value);
+  }
+}
+
+function parseParamValue(name: string, param: schema.Parameter, value: string) {
+  const ptype = parseParameterType(param.Type);
+
+  if (ptype.source === 'ssm') {
+    throw new Error('SSM parameter values not yet supported');
+  }
+
+  let ret: ContextValue;
+  if (ptype.type === 'list') {
+    ret = value.split(',').map((x) => parseScalar(x, ptype.elementType));
+  } else {
+    ret = parseScalar(value, ptype);
+  }
+
+  if (param.AllowedValues && !param.AllowedValues.includes(assertString(ret))) {
+    throw new Error(
+      `Parameter ${name} ${
+        param.ConstraintDescription ?? `not in list ${param.AllowedValues}`
+      }`
+    );
+  }
+
+  if (
+    param.AllowedPattern &&
+    !new RegExp(param.AllowedPattern).test(assertString(ret))
+  ) {
+    throw new Error(
+      `Parameter ${name} ${
+        param.ConstraintDescription ??
+        `does not match pattern ${param.AllowedPattern}`
+      }`
+    );
+  }
+
+  // FIXME: More validations here
+
+  return ret;
+
+  function parseScalar(scalar: string, type: ScalarParameterType) {
+    switch (type.type) {
+      case 'number':
+        return parseNumber(scalar).asString;
+      case 'string':
+        return scalar;
+    }
+  }
+}
+
+function assertString(x: ContextValue): string {
+  if (typeof x !== 'string') {
+    throw new Error(`Expected string, got ${JSON.stringify(x)}`);
+  }
+  return x;
+}
+
+function parseParameterType(specifier: string): ParameterType {
+  let source: ParameterSource = { source: 'direct' };
+  const m = specifier.match(/^AWS::SSM::Parameter::Value<(.*)>$/);
+  if (m) {
+    source = { source: 'ssm' };
+    specifier = m[1];
+  }
+
+  if (specifier === 'CommaDelimitedList') {
+    specifier = 'List<String>';
+  }
+
+  let isList = false;
+  const mm = specifier.match(/^List<(.*)>$/);
+  if (mm) {
+    isList = true;
+    specifier = mm[1];
+  }
+
+  let type: ScalarParameterType;
+  switch (specifier) {
+    case 'String':
+      type = { type: 'string' };
+      break;
+    case 'Number':
+      type = { type: 'number' };
+      break;
+    default:
+      type = {
+        type: 'string',
+        resourceIdentifier: specifier as ResourceIdentifier,
+      };
+      break;
+  }
+
+  return {
+    ...source,
+    ...(isList ? { type: 'list', elementType: type } : type),
+  };
+}
+
+export type ParameterType = (
+  | ScalarParameterType
+  | { readonly type: 'list'; readonly elementType: ScalarParameterType }
+) &
+  ParameterSource;
+
+export type ParameterSource =
+  | { readonly source: 'direct' }
+  | { readonly source: 'ssm' };
+
+export type ScalarParameterType =
+  | { readonly type: 'string' }
+  | { readonly type: 'number' }
+  | {
+      readonly type: 'string';
+      readonly resourceIdentifier: ResourceIdentifier;
+    };
+
+export type ResourceIdentifier =
+  | 'AWS::EC2::AvailabilityZone::Name'
+  | 'AWS::EC2::Image::Id'
+  | 'AWS::EC2::Instance::Id'
+  | 'AWS::EC2::KeyPair::KeyName'
+  | 'AWS::EC2::SecurityGroup::GroupName'
+  | 'AWS::EC2::SecurityGroup::Id'
+  | 'AWS::EC2::Subnet::Id'
+  | 'AWS::EC2::Volume::Id'
+  | 'AWS::EC2::VPC::Id'
+  | 'AWS::Route53::HostedZone::Id'
+  | 'AWS::SSM::Parameter::Name';

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -1,0 +1,111 @@
+import {
+  assertField,
+  assertObject,
+  assertString,
+  assertStringOrList,
+  parseRetentionPolicy,
+} from '../private/types';
+import { schema } from '../schema';
+import { RetentionPolicy } from './enums';
+import { ifField, parseObject, TemplateExpression } from './expression';
+
+export interface TemplateResource {
+  readonly type: string;
+  readonly properties: Record<string, TemplateExpression>;
+  readonly conditionName?: string;
+  readonly dependencies: Set<string>;
+  readonly deletionPolicy: RetentionPolicy;
+  readonly updateReplacePolicy: RetentionPolicy;
+  readonly metadata: Record<string, unknown>;
+  // readonly creationPolicy?: CreationPolicy;
+  // readonly updatePolicy?: UpdatePolicy;
+}
+
+export function parseTemplateResource(
+  resource: schema.Resource
+): TemplateResource {
+  const properties = parseObject(resource.Properties);
+
+  return {
+    type: assertString(assertField(resource, 'Type')),
+    properties,
+    conditionName: ifField(resource, 'Condition', assertString),
+    metadata: assertObject(resource.Metadata ?? {}),
+    dependencies: new Set([
+      ...(ifField(resource, 'DependsOn', assertStringOrList) ?? []),
+      ...findReferencedLogicalIds(properties),
+    ]),
+    deletionPolicy:
+      ifField(resource, 'DeletionPolicy', parseRetentionPolicy) ?? 'Delete',
+    updateReplacePolicy:
+      ifField(resource, 'UpdateReplacePolicy', parseRetentionPolicy) ??
+      'Delete',
+  };
+}
+
+function findReferencedLogicalIds(
+  xs: Record<string, TemplateExpression>,
+  into: string[] = []
+): string[] {
+  Object.values(xs).forEach(recurse);
+  return into;
+
+  function recurse(x: TemplateExpression) {
+    switch (x.type) {
+      case 'array':
+        x.array.forEach(recurse);
+        break;
+      case 'object':
+        Object.values(x.fields).forEach(recurse);
+        break;
+      case 'intrinsic':
+        switch (x.fn) {
+          case 'ref':
+          case 'getAtt':
+            into.push(x.logicalId);
+            break;
+          case 'base64':
+            recurse(x.expression);
+            break;
+          case 'cidr':
+            recurse(x.count);
+            recurse(x.ipBlock);
+            recurse(x.netMask);
+            break;
+          case 'findInMap':
+            recurse(x.key1);
+            recurse(x.key2);
+            break;
+          case 'getAzs':
+            recurse(x.region);
+            break;
+          case 'if':
+            recurse(x.then);
+            recurse(x.else);
+            break;
+          case 'importValue':
+            recurse(x.export);
+            break;
+          case 'join':
+            recurse(x.array);
+            break;
+          case 'select':
+            recurse(x.index);
+            recurse(x.array);
+            break;
+          case 'split':
+            recurse(x.value);
+            break;
+          case 'sub':
+            Object.values(x.additionalContext).forEach(recurse);
+            break;
+          case 'transform':
+            Object.values(x.parameters).forEach(recurse);
+            break;
+          default:
+            throw new Error(`Unrecognized intrinsic for evaluation: ${x.fn}`);
+        }
+        break;
+    }
+  }
+}

--- a/src/parser/template/template.ts
+++ b/src/parser/template/template.ts
@@ -1,0 +1,102 @@
+import { promises as fs } from 'fs';
+import { parseCfnYaml } from '../private/cfn-yaml';
+import { DependencyGraph } from '../private/toposort';
+import { schema } from '../schema';
+import { parseExpression, TemplateExpression } from './expression';
+import { parseMapping, TemplateMapping } from './mappings';
+import { parseOutput, TemplateOutput } from './output';
+import { TemplateParameters } from './parameters';
+import { parseTemplateResource, TemplateResource } from './resource';
+
+/**
+ * A template describes the desired state of some infrastructure
+ */
+export class Template {
+  public static async fromFile(fileName: string): Promise<Template> {
+    const tpl = parseCfnYaml(
+      await fs.readFile(fileName, { encoding: 'utf-8' })
+    );
+    if (!tpl.Resources) {
+      throw new Error(`${fileName}: does not look like a template`);
+    }
+    return new Template(tpl);
+  }
+
+  public static empty(): Template {
+    return new Template({
+      Resources: {},
+    });
+  }
+
+  public readonly parameters: TemplateParameters;
+  public readonly resources: Map<string, TemplateResource>;
+  public readonly conditions: Map<string, TemplateExpression>;
+  public readonly mappings: Map<string, TemplateMapping>;
+  public readonly outputs: Map<string, TemplateOutput>;
+
+  constructor(private readonly template: schema.Template) {
+    this.parameters = new TemplateParameters(this.template.Parameters ?? {});
+
+    this.resources = new Map(
+      Object.entries(template.Resources ?? {}).map(([k, v]) => [
+        k,
+        parseTemplateResource(v),
+      ])
+    );
+
+    this.conditions = new Map(
+      Object.entries(template.Conditions ?? {}).map(([k, v]) => [
+        k,
+        parseExpression(v),
+      ])
+    );
+
+    this.mappings = new Map(
+      Object.entries(template.Mappings ?? {}).map(([k, v]) => [
+        k,
+        parseMapping(v),
+      ])
+    );
+
+    this.outputs = new Map(
+      Object.entries(template.Outputs ?? {}).map(([k, v]) => [
+        k,
+        parseOutput(v),
+      ])
+    );
+  }
+
+  public resource(logicalId: string) {
+    const r = this.resources.get(logicalId);
+    if (!r) {
+      console.log(this.resources);
+      console.log(new Error('').stack);
+      throw new Error(`No such resource: ${logicalId}`);
+    }
+    return r;
+  }
+
+  public condition(logicalId: string) {
+    const condition = this.conditions.get(logicalId);
+    if (!condition) {
+      throw new Error(`No such Condition: ${logicalId}`);
+    }
+    return condition;
+  }
+
+  /**
+   * Return a graph containing all dependencies in execution order
+   *
+   * This includes relations established both by property references, as
+   * well as 'DependsOn' declarations.
+   */
+  public resourceGraph(): DependencyGraph<TemplateResource> {
+    const dependencies = new Map(
+      Object.entries(this.resources).map(([k, v]) => [k, v.dependencies])
+    );
+    return new DependencyGraph(
+      Object.fromEntries(this.resources.entries()),
+      dependencies
+    );
+  }
+}


### PR DESCRIPTION
Copied the parser bits from [cfnengine]. I left the evaluation part out because it doesn't seem to be directly useful for deCDK. 

The next step is to implement an evaluator, based on the same principles, but one that converts the AST into resources in a CDK stack. Once we have that, we can remove `graph.ts`, `object-matchers.ts` and most of `deconstruction.ts`.


[cfnengine]: https://github.com/rix0rrr/cfngine