### PR TITLE
fix: parser uses unsupported yaml schema

### DIFF
--- a/src/parser/private/cfn-yaml.ts
+++ b/src/parser/private/cfn-yaml.ts
@@ -26,7 +26,7 @@ const shortForms: yaml_types.Schema.CustomTag[] = [
 export function parseCfnYaml(text: string): any {
   return yaml.parse(text, {
     customTags: shortForms,
-    schema: 'core',
+    schema: 'yaml-1.1',
   });
 }
 


### PR DESCRIPTION
> AWS CloudFormation supports the YAML Version 1.1 specification with a few exceptions.

Source: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-formats.html