### PR TITLE
fix: `Fn::GetAtt` dot notation shorthand is not supported

### DIFF
--- a/examples/apigw.json
+++ b/examples/apigw.json
@@ -26,7 +26,7 @@
     "GetRoot": {
       "Type": "aws-cdk-lib.aws_apigateway.Method",
       "Properties": {
-        "resource": { "Fn::GetAtt": ["MyApi", "root"] },
+        "resource": { "Fn::GetAtt": "MyApi.root" },
         "httpMethod": "GET"
       }
     }

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -114,7 +114,7 @@ export namespace schema {
     'Fn::FindInMap': [CfnValue<string>, CfnValue<string>, CfnValue<string>];
   };
   export type FnGetAZs = { 'Fn::GetAZs': string | Ref };
-  export type FnGetAtt = { 'Fn::GetAtt': [string, string | Ref] };
+  export type FnGetAtt = { 'Fn::GetAtt': string | [string, string | Ref] };
   export type FnIf = { 'Fn::If': [string, CfnValue<any>, CfnValue<any>] };
   export type FnImportValue = { 'Fn::ImportValue': CfnValue<string> };
   export type FnJoin = {

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -180,6 +180,9 @@ export function parseExpression(x: unknown): TemplateExpression {
       logicalId: assertString(value),
     }),
     'Fn::GetAtt': (value) => {
+      if (typeof value == 'string') {
+        value = value.split('.');
+      }
       const xs = assertList(value, [2]);
       return {
         type: 'intrinsic',


### PR DESCRIPTION
## Note
CFN has an undocumented behavior where dot notation shorthand of `Fn::GetAtt` is
supported in JSON template as well. This change add support to handle such scenario.

## Test
`yarn build`

Fixes #211 