### PR TITLE
fix: synthesizer not working

### DIFF
--- a/src/decdk.ts
+++ b/src/decdk.ts
@@ -22,7 +22,15 @@ async function main() {
   const typeSystem = await loadTypeSystem();
 
   const app = new cdk.App();
-  new DeclarativeStack(app, stackName, { template, typeSystem });
+  new DeclarativeStack(app, stackName, {
+    template,
+    typeSystem,
+    env: {
+      account:
+        process.env.CDK_DEPLOY_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEPLOY_REGION || process.env.CDK_DEFAULT_REGION,
+    },
+  });
   app.synth();
 }
 

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -12,13 +12,7 @@ export interface DeclarativeStackProps extends cdk.StackProps {
 
 export class DeclarativeStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: DeclarativeStackProps) {
-    super(scope, id, {
-      env: {
-        account:
-          process.env.CDK_DEPLOY_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT,
-        region: process.env.CDK_DEPLOY_REGION || process.env.CDK_DEFAULT_REGION,
-      },
-    });
+    super(scope, id, props);
 
     const typeSystem = props.typeSystem;
     const template = new TypedTemplate(props.template, { typeSystem });


### PR DESCRIPTION
Fixes #12 

---
Previously `DeclarativeStack` wasn't passing on any `StackProps`.
Also moved the `env` setup to the cli as this is where it's actually required. When using `DeclarativeStack` as a library the defaults don't make sense.