### PR TITLE
fix: generation of enum-like schemas leads to a cyclic reference

### DIFF
--- a/examples/method-calls.json
+++ b/examples/method-calls.json
@@ -25,6 +25,15 @@
         }
       }
     },
+    "Grant": {
+      "Type": "aws-cdk-lib.aws_iam.Grant",
+      "On": "SourceBucket",
+      "Call": {
+        "grantRead": {
+          "identity": {"Ref": "MyFunction"}
+        }
+      }
+    },
     "Alias": {
       "Type": "aws-cdk-lib.aws_lambda.Alias",
       "On": "MyFunction",

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -50,6 +50,7 @@ export function parseTemplateResource(
   assertAtMostOneOfFields(resource, ['Properties', 'Call']);
 
   const properties = parseObject(resource.Properties);
+  const call = parseCall(resource.Call);
 
   return {
     type: assertString(assertField(resource, 'Type')),
@@ -60,6 +61,7 @@ export function parseTemplateResource(
       ...(ifField(resource, 'DependsOn', assertStringOrList) ?? []),
       ...singletonList(ifField(resource, 'On', assertString)),
       ...findReferencedLogicalIds(properties),
+      ...findReferencedLogicalIds({ _: call }),
     ]),
     dependsOn: new Set([
       ...(ifField(resource, 'DependsOn', assertStringOrList) ?? []),
@@ -72,7 +74,7 @@ export function parseTemplateResource(
     tags: parseTags(resource.Tags),
     overrides: parseOverrides(resource.Overrides),
     on: ifField(resource, 'On', assertString),
-    call: parseCall(resource.Call),
+    call,
   };
 }
 

--- a/src/schema/cdk-schema.ts
+++ b/src/schema/cdk-schema.ts
@@ -126,9 +126,7 @@ export function renderFullSchema(
   );
 
   for (const type of enumLikeClasses) {
-    addResource(
-      ctx.define(type.spec.fqn, () => schemaForEnumLikeClass(type, ctx))
-    );
+    addResource(schemaForEnumLikeClass(type, ctx));
   }
 
   output.properties.$schema = {

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -431,25 +431,24 @@ export function schemaForEnumLikeClass(
         [`${method.parentType.fqn}.${method.name}`]: methodSchema(method, ctx),
       },
     });
-    anyOf.push({
-      additionalProperties: false,
-      type: 'object',
-      properties: {
-        Type: {
-          type: 'string',
-        },
-        Call: {
-          type: 'object',
-          properties: {
-            [`${method.parentType.fqn}.${method.name}`]: methodSchema(
-              method,
-              ctx
-            ),
-          },
-        },
-      },
-    });
   }
+
+  anyOf.push({
+    additionalProperties: false,
+    type: 'object',
+    properties: {
+      Type: {
+        type: 'string',
+        enum: [type.fqn],
+      },
+      Call: {
+        type: 'object',
+      },
+      On: {
+        type: 'string',
+      },
+    },
+  });
 
   if (anyOf.length === 0) {
     return undefined;

--- a/src/type-resolution/resolve.ts
+++ b/src/type-resolution/resolve.ts
@@ -66,9 +66,11 @@ export function resolveExpressionType(
     case ResolvableExpressionType.UNION_OF_TYPES:
       return resolveUnionOfTypesExpression(x, assertUnionOfTypes(typeRef));
     case ResolvableExpressionType.STRUCT:
-      return resolveStructExpression(
-        assertExpressionType(x, 'object'),
-        assertInterface(typeRef)
+      return refOrResolve(x, (y) =>
+        resolveStructExpression(
+          assertExpressionType(y, 'object'),
+          assertInterface(typeRef)
+        )
       );
     case ResolvableExpressionType.ENUM:
       return resolveEnumExpression(

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -2252,6 +2252,141 @@ Object {
 }
 `;
 
+exports[`method-calls.json 1`] = `
+Object {
+  "Resources": Object {
+    "MyFunction3BAA72D1": Object {
+      "DependsOn": Array [
+        "MyFunctionServiceRoleDefaultPolicyB705ABD4",
+        "MyFunctionServiceRole3C357FF2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "SourceBucketDDD2130A",
+          },
+          "S3Key": "foo-bar",
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "MyFunctionServiceRole3C357FF2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "MyFunctionAliaslive8B92D042": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "MyFunction3BAA72D1",
+        },
+        "FunctionVersion": Object {
+          "Fn::GetAtt": Array [
+            "MyFunctionCurrentVersion197490AF4063a7e304a1f5a926b2da07afacb434",
+            "Version",
+          ],
+        },
+        "Name": "live",
+      },
+      "Type": "AWS::Lambda::Alias",
+    },
+    "MyFunctionCurrentVersion197490AF4063a7e304a1f5a926b2da07afacb434": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "MyFunction3BAA72D1",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
+    },
+    "MyFunctionServiceRole3C357FF2": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MyFunctionServiceRoleDefaultPolicyB705ABD4": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "SourceBucketDDD2130A",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "SourceBucketDDD2130A",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "MyFunctionServiceRoleDefaultPolicyB705ABD4",
+        "Roles": Array [
+          Object {
+            "Ref": "MyFunctionServiceRole3C357FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SourceBucketDDD2130A": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;
+
 exports[`pipeline.json 1`] = `
 Object {
   "Resources": Object {
@@ -3506,94 +3641,6 @@ Object {
         },
       },
       "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Retain",
-    },
-  },
-}
-`;
-
-exports[`reusable-lambda-code.json 1`] = `
-Object {
-  "Resources": Object {
-    "MyFunction3BAA72D1": Object {
-      "DependsOn": Array [
-        "MyFunctionServiceRole3C357FF2",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Ref": "SourceBucketDDD2130A",
-          },
-          "S3Key": "foo-bar",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "MyFunctionServiceRole3C357FF2",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyFunctionAliaslive8B92D042": Object {
-      "Properties": Object {
-        "FunctionName": Object {
-          "Ref": "MyFunction3BAA72D1",
-        },
-        "FunctionVersion": Object {
-          "Fn::GetAtt": Array [
-            "MyFunctionCurrentVersion197490AF4063a7e304a1f5a926b2da07afacb434",
-            "Version",
-          ],
-        },
-        "Name": "live",
-      },
-      "Type": "AWS::Lambda::Alias",
-    },
-    "MyFunctionCurrentVersion197490AF4063a7e304a1f5a926b2da07afacb434": Object {
-      "Properties": Object {
-        "FunctionName": Object {
-          "Ref": "MyFunction3BAA72D1",
-        },
-      },
-      "Type": "AWS::Lambda::Version",
-    },
-    "MyFunctionServiceRole3C357FF2": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "SourceBucketDDD2130A": Object {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
   },

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -1954,7 +1954,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
+          "S3Key": "731f24951dbe4e08bfc519dd7c23a4f7158528bd5557e38437b08292ab2a873c.zip",
         },
         "Description": "/opt/awscli/aws",
       },

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -117,14 +117,13 @@ test('schemaForInterface: Behavioral Interface Implementation Factories', async 
           additionalProperties: false,
           properties: {
             Call: {
-              properties: {
-                'fixture.FeatureFactory.baseFeature': {
-                  $ref: '#/definitions/fixture.FeatureFactory.baseFeature',
-                },
-              },
               type: 'object',
             },
             Type: {
+              type: 'string',
+              enum: ['fixture.FeatureFactory'],
+            },
+            On: {
               type: 'string',
             },
           },

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -2381,6 +2381,384 @@ TypedTemplate {
 }
 `;
 
+exports[`method-calls.json 1`] = `
+TypedTemplate {
+  "conditions": Map {},
+  "mappings": Map {},
+  "outputs": Map {},
+  "parameters": TemplateParameters {
+    "parameters": Object {},
+  },
+  "resources": DependencyGraph {
+    "_dependencies": Map {
+      "SourceBucket" => Set {},
+      "BusinessLogic" => Set {
+        "SourceBucket",
+      },
+      "MyFunction" => Set {
+        "BusinessLogic",
+      },
+      "Grant" => Set {
+        "SourceBucket",
+        "MyFunction",
+      },
+      "Alias" => Set {
+        "MyFunction",
+      },
+    },
+    "keys": Set {
+      "SourceBucket",
+      "BusinessLogic",
+      "MyFunction",
+      "Grant",
+      "Alias",
+    },
+    "nodes": Object {
+      "Alias": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "type": "string",
+                "value": "live",
+              },
+              Object {
+                "fields": Object {},
+                "type": "struct",
+              },
+            ],
+            "type": "array",
+          },
+          "logicalId": "MyFunction",
+          "method": "addAlias",
+          "type": "instanceMethodCall",
+        },
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_lambda.Alias",
+        "logicalId": "Alias",
+        "namespace": "aws_lambda",
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
+      "BusinessLogic": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "reference": Object {
+                  "fn": "ref",
+                  "logicalId": "SourceBucket",
+                  "type": "intrinsic",
+                },
+                "type": "resolve-reference",
+              },
+              Object {
+                "type": "string",
+                "value": "foo-bar",
+              },
+              Object {
+                "type": "void",
+              },
+            ],
+            "type": "array",
+          },
+          "fqn": "aws-cdk-lib.aws_lambda.Code",
+          "method": "fromBucket",
+          "namespace": "aws_lambda",
+          "type": "staticMethodCall",
+        },
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_lambda.Code",
+        "logicalId": "BusinessLogic",
+        "namespace": "aws_lambda",
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
+      "Grant": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "reference": Object {
+                  "fn": "ref",
+                  "logicalId": "MyFunction",
+                  "type": "intrinsic",
+                },
+                "type": "resolve-reference",
+              },
+              Object {
+                "type": "void",
+              },
+            ],
+            "type": "array",
+          },
+          "logicalId": "SourceBucket",
+          "method": "grantRead",
+          "type": "instanceMethodCall",
+        },
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_iam.Grant",
+        "logicalId": "Grant",
+        "namespace": "aws_iam",
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
+      "MyFunction": Object {
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_lambda.Function",
+        "logicalId": "MyFunction",
+        "namespace": "aws_lambda",
+        "overrides": Array [],
+        "props": Object {
+          "fields": Object {
+            "code": Object {
+              "reference": Object {
+                "fn": "ref",
+                "logicalId": "BusinessLogic",
+                "type": "intrinsic",
+              },
+              "type": "resolve-reference",
+            },
+            "handler": Object {
+              "type": "string",
+              "value": "index.handler",
+            },
+            "runtime": Object {
+              "fqn": "aws-cdk-lib.aws_lambda.Runtime",
+              "namespace": "aws_lambda",
+              "property": "NODEJS_14_X",
+              "type": "staticProperty",
+            },
+          },
+          "type": "struct",
+        },
+        "tags": Array [],
+        "type": "construct",
+      },
+      "SourceBucket": Object {
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_s3.Bucket",
+        "logicalId": "SourceBucket",
+        "namespace": "aws_s3",
+        "overrides": Array [],
+        "props": Object {
+          "fields": Object {},
+          "type": "struct",
+        },
+        "tags": Array [],
+        "type": "construct",
+      },
+    },
+  },
+  "template": Template {
+    "conditions": Map {},
+    "mappings": Map {},
+    "outputs": Map {},
+    "parameters": TemplateParameters {
+      "parameters": Object {},
+    },
+    "resources": Map {
+      "SourceBucket" => Object {
+        "call": Object {
+          "fields": Object {},
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {},
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_s3.Bucket",
+        "updateReplacePolicy": "Delete",
+      },
+      "BusinessLogic" => Object {
+        "call": Object {
+          "fields": Object {
+            "aws-cdk-lib.aws_lambda.Code.fromBucket": Object {
+              "fields": Object {
+                "bucket": Object {
+                  "fn": "ref",
+                  "logicalId": "SourceBucket",
+                  "type": "intrinsic",
+                },
+                "key": Object {
+                  "type": "string",
+                  "value": "foo-bar",
+                },
+              },
+              "type": "object",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "SourceBucket",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_lambda.Code",
+        "updateReplacePolicy": "Delete",
+      },
+      "MyFunction" => Object {
+        "call": Object {
+          "fields": Object {},
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "BusinessLogic",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {
+          "code": Object {
+            "fn": "ref",
+            "logicalId": "BusinessLogic",
+            "type": "intrinsic",
+          },
+          "handler": Object {
+            "type": "string",
+            "value": "index.handler",
+          },
+          "runtime": Object {
+            "type": "string",
+            "value": "NODEJS_14_X",
+          },
+        },
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_lambda.Function",
+        "updateReplacePolicy": "Delete",
+      },
+      "Grant" => Object {
+        "call": Object {
+          "fields": Object {
+            "grantRead": Object {
+              "fields": Object {
+                "identity": Object {
+                  "fn": "ref",
+                  "logicalId": "MyFunction",
+                  "type": "intrinsic",
+                },
+              },
+              "type": "object",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "SourceBucket",
+          "MyFunction",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": "SourceBucket",
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_iam.Grant",
+        "updateReplacePolicy": "Delete",
+      },
+      "Alias" => Object {
+        "call": Object {
+          "fields": Object {
+            "addAlias": Object {
+              "fields": Object {
+                "aliasName": Object {
+                  "type": "string",
+                  "value": "live",
+                },
+              },
+              "type": "object",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "MyFunction",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": "MyFunction",
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_lambda.Alias",
+        "updateReplacePolicy": "Delete",
+      },
+    },
+    "template": Object {
+      "$schema": "../cdk.schema.json",
+      "Resources": Object {
+        "Alias": Object {
+          "Call": Object {
+            "addAlias": Object {
+              "aliasName": "live",
+            },
+          },
+          "On": "MyFunction",
+          "Type": "aws-cdk-lib.aws_lambda.Alias",
+        },
+        "BusinessLogic": Object {
+          "Call": Object {
+            "aws-cdk-lib.aws_lambda.Code.fromBucket": Object {
+              "bucket": Object {
+                "Ref": "SourceBucket",
+              },
+              "key": "foo-bar",
+            },
+          },
+          "Type": "aws-cdk-lib.aws_lambda.Code",
+        },
+        "Grant": Object {
+          "Call": Object {
+            "grantRead": Object {
+              "identity": Object {
+                "Ref": "MyFunction",
+              },
+            },
+          },
+          "On": "SourceBucket",
+          "Type": "aws-cdk-lib.aws_iam.Grant",
+        },
+        "MyFunction": Object {
+          "Properties": Object {
+            "code": Object {
+              "Ref": "BusinessLogic",
+            },
+            "handler": "index.handler",
+            "runtime": "NODEJS_14_X",
+          },
+          "Type": "aws-cdk-lib.aws_lambda.Function",
+        },
+        "SourceBucket": Object {
+          "Type": "aws-cdk-lib.aws_s3.Bucket",
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`pipeline.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
@@ -3298,303 +3676,6 @@ TypedTemplate {
             "encryption": "KMS",
           },
           "Type": "aws-cdk-lib.aws_sqs.Queue",
-        },
-      },
-    },
-  },
-}
-`;
-
-exports[`reusable-lambda-code.json 1`] = `
-TypedTemplate {
-  "conditions": Map {},
-  "mappings": Map {},
-  "outputs": Map {},
-  "parameters": TemplateParameters {
-    "parameters": Object {},
-  },
-  "resources": DependencyGraph {
-    "_dependencies": Map {
-      "SourceBucket" => Set {},
-      "BusinessLogic" => Set {},
-      "MyFunction" => Set {
-        "BusinessLogic",
-      },
-      "Alias" => Set {
-        "MyFunction",
-      },
-    },
-    "keys": Set {
-      "SourceBucket",
-      "BusinessLogic",
-      "MyFunction",
-      "Alias",
-    },
-    "nodes": Object {
-      "Alias": Object {
-        "call": Object {
-          "args": Object {
-            "array": Array [
-              Object {
-                "type": "string",
-                "value": "live",
-              },
-              Object {
-                "fields": Object {},
-                "type": "struct",
-              },
-            ],
-            "type": "array",
-          },
-          "logicalId": "MyFunction",
-          "method": "addAlias",
-          "type": "instanceMethodCall",
-        },
-        "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_lambda.Alias",
-        "logicalId": "Alias",
-        "namespace": "aws_lambda",
-        "overrides": Array [],
-        "tags": Array [],
-        "type": "lazyResource",
-      },
-      "BusinessLogic": Object {
-        "call": Object {
-          "args": Object {
-            "array": Array [
-              Object {
-                "reference": Object {
-                  "fn": "ref",
-                  "logicalId": "SourceBucket",
-                  "type": "intrinsic",
-                },
-                "type": "resolve-reference",
-              },
-              Object {
-                "type": "string",
-                "value": "foo-bar",
-              },
-              Object {
-                "type": "void",
-              },
-            ],
-            "type": "array",
-          },
-          "fqn": "aws-cdk-lib.aws_lambda.Code",
-          "method": "fromBucket",
-          "namespace": "aws_lambda",
-          "type": "staticMethodCall",
-        },
-        "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_lambda.Code",
-        "logicalId": "BusinessLogic",
-        "namespace": "aws_lambda",
-        "overrides": Array [],
-        "tags": Array [],
-        "type": "lazyResource",
-      },
-      "MyFunction": Object {
-        "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_lambda.Function",
-        "logicalId": "MyFunction",
-        "namespace": "aws_lambda",
-        "overrides": Array [],
-        "props": Object {
-          "fields": Object {
-            "code": Object {
-              "reference": Object {
-                "fn": "ref",
-                "logicalId": "BusinessLogic",
-                "type": "intrinsic",
-              },
-              "type": "resolve-reference",
-            },
-            "handler": Object {
-              "type": "string",
-              "value": "index.handler",
-            },
-            "runtime": Object {
-              "fqn": "aws-cdk-lib.aws_lambda.Runtime",
-              "namespace": "aws_lambda",
-              "property": "NODEJS_14_X",
-              "type": "staticProperty",
-            },
-          },
-          "type": "struct",
-        },
-        "tags": Array [],
-        "type": "construct",
-      },
-      "SourceBucket": Object {
-        "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_s3.Bucket",
-        "logicalId": "SourceBucket",
-        "namespace": "aws_s3",
-        "overrides": Array [],
-        "props": Object {
-          "fields": Object {},
-          "type": "struct",
-        },
-        "tags": Array [],
-        "type": "construct",
-      },
-    },
-  },
-  "template": Template {
-    "conditions": Map {},
-    "mappings": Map {},
-    "outputs": Map {},
-    "parameters": TemplateParameters {
-      "parameters": Object {},
-    },
-    "resources": Map {
-      "SourceBucket" => Object {
-        "call": Object {
-          "fields": Object {},
-          "type": "object",
-        },
-        "conditionName": undefined,
-        "deletionPolicy": "Delete",
-        "dependencies": Set {},
-        "dependsOn": Set {},
-        "metadata": Object {},
-        "on": undefined,
-        "overrides": Array [],
-        "properties": Object {},
-        "tags": Array [],
-        "type": "aws-cdk-lib.aws_s3.Bucket",
-        "updateReplacePolicy": "Delete",
-      },
-      "BusinessLogic" => Object {
-        "call": Object {
-          "fields": Object {
-            "aws-cdk-lib.aws_lambda.Code.fromBucket": Object {
-              "fields": Object {
-                "bucket": Object {
-                  "fn": "ref",
-                  "logicalId": "SourceBucket",
-                  "type": "intrinsic",
-                },
-                "key": Object {
-                  "type": "string",
-                  "value": "foo-bar",
-                },
-              },
-              "type": "object",
-            },
-          },
-          "type": "object",
-        },
-        "conditionName": undefined,
-        "deletionPolicy": "Delete",
-        "dependencies": Set {},
-        "dependsOn": Set {},
-        "metadata": Object {},
-        "on": undefined,
-        "overrides": Array [],
-        "properties": Object {},
-        "tags": Array [],
-        "type": "aws-cdk-lib.aws_lambda.Code",
-        "updateReplacePolicy": "Delete",
-      },
-      "MyFunction" => Object {
-        "call": Object {
-          "fields": Object {},
-          "type": "object",
-        },
-        "conditionName": undefined,
-        "deletionPolicy": "Delete",
-        "dependencies": Set {
-          "BusinessLogic",
-        },
-        "dependsOn": Set {},
-        "metadata": Object {},
-        "on": undefined,
-        "overrides": Array [],
-        "properties": Object {
-          "code": Object {
-            "fn": "ref",
-            "logicalId": "BusinessLogic",
-            "type": "intrinsic",
-          },
-          "handler": Object {
-            "type": "string",
-            "value": "index.handler",
-          },
-          "runtime": Object {
-            "type": "string",
-            "value": "NODEJS_14_X",
-          },
-        },
-        "tags": Array [],
-        "type": "aws-cdk-lib.aws_lambda.Function",
-        "updateReplacePolicy": "Delete",
-      },
-      "Alias" => Object {
-        "call": Object {
-          "fields": Object {
-            "addAlias": Object {
-              "fields": Object {
-                "aliasName": Object {
-                  "type": "string",
-                  "value": "live",
-                },
-              },
-              "type": "object",
-            },
-          },
-          "type": "object",
-        },
-        "conditionName": undefined,
-        "deletionPolicy": "Delete",
-        "dependencies": Set {
-          "MyFunction",
-        },
-        "dependsOn": Set {},
-        "metadata": Object {},
-        "on": "MyFunction",
-        "overrides": Array [],
-        "properties": Object {},
-        "tags": Array [],
-        "type": "aws-cdk-lib.aws_lambda.Alias",
-        "updateReplacePolicy": "Delete",
-      },
-    },
-    "template": Object {
-      "$schema": "../cdk.schema.json",
-      "Resources": Object {
-        "Alias": Object {
-          "Call": Object {
-            "addAlias": Object {
-              "aliasName": "live",
-            },
-          },
-          "On": "MyFunction",
-          "Type": "aws-cdk-lib.aws_lambda.Alias",
-        },
-        "BusinessLogic": Object {
-          "Call": Object {
-            "aws-cdk-lib.aws_lambda.Code.fromBucket": Object {
-              "bucket": Object {
-                "Ref": "SourceBucket",
-              },
-              "key": "foo-bar",
-            },
-          },
-          "Type": "aws-cdk-lib.aws_lambda.Code",
-        },
-        "MyFunction": Object {
-          "Properties": Object {
-            "code": Object {
-              "Ref": "BusinessLogic",
-            },
-            "handler": "index.handler",
-            "runtime": "NODEJS_14_X",
-          },
-          "Type": "aws-cdk-lib.aws_lambda.Function",
-        },
-        "SourceBucket": Object {
-          "Type": "aws-cdk-lib.aws_s3.Bucket",
         },
       },
     },


### PR DESCRIPTION
`schemaForEnumLikeClass()` already calls `Context.define()`. By calling it again, it led to a cycle, which ultimately resulted in enum like classes not being added to the schema.

This change also relaxes the schema for method calls, accepting any object in the `Call` property. The current implementation generates, for each enum-like class, a schema with all its static methods. But with support for instance calls, this is no longer correct, as the method name will depend on the target of the call, not on the return type. In fact, it may not be possible to create a 100% schema in this case. We can come back to this later and improve the schema, if necessary.