### PR TITLE
feat: `CDK::GetProp`

### DIFF
--- a/docs/architecture/decisions/0005-custom-intrinsic-to-get-values-from-constructs.md
+++ b/docs/architecture/decisions/0005-custom-intrinsic-to-get-values-from-constructs.md
@@ -1,0 +1,49 @@
+# 5. Custom intrinsic to get values from Constructs
+
+Date: 2022-09-12
+
+## Status
+
+Accepted
+
+## Context
+
+In CloudFormation the `Fn::GetAtt` intrinsic function returns the value of
+Resource Attributes. It can be used to reference these values in other
+Resources. With deCDK users might now also want to reference the Properties of
+their Constructs.
+
+We could overload the `Fn::GetAtt` intrinsic to also return Property values.
+However this might be confusing. `CfnAtt` does not exist on the Construct (it's
+a CFN attribute). What should `{ 'Fn::GetAtt': ['CdkConstruct', 'CfnAtt'] }`
+then return?
+
+- `CdkConstruct.CfnAtt` or
+- `CdkConstruct.defaultChild.CfnAtt`?
+
+Here an answer could be to attempt both. However in some situations
+CloudFormation attributes and Construct props are sharing the same name. For
+`Name` and `name` the difference is only the case of the first letter. Should we
+still attempt to return both?
+
+The alternative is to make it explicit what the target of the intrinsic function
+is. `Fn::GetAtt` can always refer to a CloudFormation Resource Attributes and a
+new intrinsic `CDK:GetProp` can always refer to Construct Properties
+
+## Decision
+
+We introduce a new custom intrinsic function `CDK:GetProp` to return values from
+CDK constructs.
+
+`CDK:GetProp` cannot be used with a CFN Resource as target. We will throw an
+error in this case.
+
+`Fn::GetAtt` will always return a CFN Resource Attribute. For Constructs, we
+will return Attributes of the default child or throw an error.
+
+## Consequences
+
+Users will make a conscious decision whether they want to reference a
+Construct Property or a Resource Attribute.
+
+We have to support parsing custom intrinsic functions.

--- a/examples/apigw.json
+++ b/examples/apigw.json
@@ -28,7 +28,7 @@
     "GetRoot": {
       "Type": "aws-cdk-lib.aws_apigateway.Method",
       "Properties": {
-        "resource": { "Fn::GetAtt": "MyApi.root" },
+        "resource": { "CDK::GetProp": "MyApi.root" },
         "httpMethod": "GET"
       }
     }

--- a/examples/lambda-policy.yaml
+++ b/examples/lambda-policy.yaml
@@ -20,7 +20,7 @@ Resources:
                 - s3:PutObject*
               Resource:
                 - { Ref: MyBucket }
-                - { Fn::Join: ['', [{ Fn::GetAtt: MyBucket.bucketArn }, '/*']] }
+                - { Fn::Join: ['', [{ Fn::GetAtt: MyBucket.Arn }, '/*']] }
 
   MyBucket:
     Type: aws-cdk-lib.aws_s3.Bucket

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -1,9 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
-import { CfnElement, Token } from 'aws-cdk-lib';
+import { Token } from 'aws-cdk-lib';
 import { Construct, IConstruct } from 'constructs';
 import { SubFragment } from '../parser/private/sub';
 import { assertBoolean, assertString } from '../parser/private/types';
-import { GetAttIntrinsic, RefIntrinsic } from '../parser/template';
+import { GetPropIntrinsic, RefIntrinsic } from '../parser/template';
 import { ResourceOverride } from '../parser/template/overrides';
 import { ResourceTag } from '../parser/template/tags';
 import { isCdkConstructExpression, ResourceLike } from '../type-resolution';
@@ -14,33 +14,47 @@ import {
 import { TypedTemplateExpression } from '../type-resolution/expression';
 import { EvaluationContext } from './context';
 import { applyOverride } from './overrides';
+import {
+  CfnResourceReference,
+  ConstructReference,
+  ValueOnlyReference,
+} from './references';
 
 export class Evaluator {
   constructor(public readonly context: EvaluationContext) {}
 
   public evaluateTemplate() {
-    return this.context.template.resources.forEach((logicalId, resource) =>
-      this.evaluateResource(logicalId, resource)
+    return this.context.template.resources.forEach((_logicalId, resource) =>
+      this.evaluateResource(resource)
     );
   }
 
-  public evaluateResource(
-    logicalId: string,
-    resource: ResourceLike
-  ): IConstruct {
+  public evaluateResource(resource: ResourceLike): IConstruct {
     const construct = this.evaluate(resource);
+
     this.applyTags(construct, resource.tags);
     this.applyDependsOn(construct, resource.dependsOn);
     if (isCdkConstructExpression(resource)) {
       this.applyOverrides(construct, resource.overrides);
     }
 
-    this.context.addReferenceable(logicalId, {
-      primaryValue: construct,
-      attributes: construct,
-    });
+    this.context.addReference(
+      this.referenceForResourceLike(resource, construct)
+    );
 
     return construct;
+  }
+
+  private referenceForResourceLike(resource: ResourceLike, value: unknown) {
+    switch (resource.type) {
+      case 'construct':
+        return new ConstructReference(resource.logicalId, value as Construct);
+      case 'resource':
+        return new CfnResourceReference(resource.logicalId, value);
+      case 'lazyResource':
+      default:
+        return new ValueOnlyReference(resource.logicalId, value);
+    }
   }
 
   public evaluate(x: TypedTemplateExpression): any {
@@ -77,7 +91,7 @@ export class Evaluator {
           case 'getAtt':
             return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
           case 'getProp':
-            return this.fnGetAtt(x.logicalId, assertString(x.property));
+            return this.fnGetProp(x.logicalId, assertString(x.property));
           case 'getAzs':
             return this.fnGetAzs(assertString(ev(x.region)));
           case 'if':
@@ -87,7 +101,7 @@ export class Evaluator {
           case 'join':
             return this.fnJoin(assertString(x.separator), ev(x.list));
           case 'ref':
-            return this.ref(x.logicalId);
+            return this.cfnRef(x.logicalId);
           case 'select':
             return this.fnSelect(ev(x.index), ev(x.objects));
           case 'split':
@@ -177,8 +191,13 @@ export class Evaluator {
     method: string,
     parameters: any[]
   ) {
-    const record = this.context.referenceable(logicalId);
-    const construct = record.primaryValue as any;
+    const record = this.context.reference(logicalId);
+    const construct = record.instance as any;
+    if (!construct || !construct?.[method]) {
+      throw Error(
+        `Expected ${logicalId} to have method ${method}, but cannot find it.`
+      );
+    }
     return construct[method](...parameters);
   }
 
@@ -230,13 +249,24 @@ export class Evaluator {
     return ret;
   }
 
-  protected fnGetAtt(logicalId: string, attr: string) {
-    const c = this.context.referenceable(logicalId);
-    const ret = c.attributes?.[attr];
-    if (ret === undefined) {
-      return cdk.Fn.getAtt(logicalId, attr);
+  protected fnGetProp(logicalId: string, prop: string) {
+    const c = this.context.reference(logicalId);
+    if (!c.instance || !c.hasProp(prop)) {
+      throw Error(
+        `CDK::GetProp: Expected Construct Property, got: ${logicalId}.${prop}`
+      );
     }
-    return ret;
+    return c.instance?.[prop];
+  }
+
+  protected fnGetAtt(logicalId: string, attribute: string) {
+    const c = this.context.reference(logicalId);
+    if (!c.hasAtt?.(attribute)) {
+      throw Error(
+        `Fn::GetAtt: Expected Cloudformation Attribute, got: ${logicalId}.${attribute}`
+      );
+    }
+    return cdk.Fn.getAtt(c.ref, attribute);
   }
 
   protected fnGetAzs(region: string) {
@@ -260,50 +290,24 @@ export class Evaluator {
     return cdk.Fn.join(separator, array);
   }
 
-  protected resolveReferences(intrinsic: RefIntrinsic | GetAttIntrinsic) {
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-
+  protected resolveReferences(intrinsic: RefIntrinsic | GetPropIntrinsic) {
     const { logicalId, fn } = intrinsic;
-    const c = this.context.referenceable(logicalId);
+    const c = this.context.reference(logicalId);
 
-    if (!c) {
-      throw new Error(
-        `Fn::${capitalize(fn)}: unknown identifier: ${logicalId}`
-      );
-    }
-
-    if (fn === 'getAtt') {
+    if (fn !== 'ref') {
       return this.evaluate(intrinsic);
     }
 
-    if (!c.primaryValue) {
-      return this.ref(logicalId);
+    if (!c.instance) {
+      return this.cfnRef(logicalId);
     }
 
-    return c.primaryValue;
+    return c.instance;
   }
 
-  private logicalIdForReference(logicalId: string) {
-    const c = this.context.referenceable(logicalId);
-    if (!c) {
-      throw new Error(`Ref: unknown identifier: ${logicalId}`);
-    }
-
-    if (
-      c.primaryValue instanceof Construct &&
-      !CfnElement.isCfnElement(c.primaryValue)
-    ) {
-      return this.context.stack.getLogicalId(
-        c.primaryValue.node.defaultChild as cdk.CfnElement
-      );
-    }
-
-    // This covers CloudFormation Resources, Parameters and Pseudo Parameters
-    return logicalId;
-  }
-
-  protected ref(logicalId: string) {
-    return cdk.Fn.ref(this.logicalIdForReference(logicalId));
+  protected cfnRef(logicalId: string) {
+    const c = this.context.reference(logicalId);
+    return cdk.Fn.ref(c.ref);
   }
 
   protected fnSelect(index: number, elements: any[]) {
@@ -337,7 +341,7 @@ export class Evaluator {
             if (part.logicalId in additionalContext) {
               return asVariable(part.logicalId);
             }
-            return asVariable(this.logicalIdForReference(part.logicalId));
+            return asVariable(this.context.reference(part.logicalId).ref);
           case 'getatt':
             const attVal = this.fnGetAtt(part.logicalId, part.attr);
             if (Token.isUnresolved(attVal)) {

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -76,6 +76,8 @@ export class Evaluator {
             );
           case 'getAtt':
             return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
+          case 'getProp':
+            return this.fnGetAtt(x.logicalId, assertString(x.property));
           case 'getAzs':
             return this.fnGetAzs(assertString(ev(x.region)));
           case 'if':

--- a/src/evaluate/references.ts
+++ b/src/evaluate/references.ts
@@ -1,0 +1,108 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+/**
+ * A referenceable record.
+ *
+ * If `attributes` is set, the references is a map of sort and can return an attribute value for a given key.
+ */
+export interface Reference {
+  logicalId: string;
+  ref: string;
+  instance?: any;
+  hasAtt(attribute: string): boolean;
+  hasProp(property: string): boolean;
+}
+
+export class References {
+  private _store: Map<string, Reference> = new Map();
+
+  public add(reference: Reference): void {
+    this._store.set(reference.logicalId, reference);
+  }
+
+  public get(logicalId: string): Reference | undefined {
+    return this._store.get(logicalId);
+  }
+}
+
+export class SimpleReference implements Reference {
+  public constructor(public readonly logicalId: string) {}
+
+  public get ref(): string {
+    return this.logicalId;
+  }
+
+  public hasAtt(_attribute: string) {
+    return false;
+  }
+
+  public hasProp(_property: string) {
+    return false;
+  }
+}
+
+export class InstanceReference extends SimpleReference {
+  public constructor(logicalId: string, public readonly instance: any) {
+    super(logicalId);
+  }
+}
+
+export class ValueOnlyReference extends InstanceReference {
+  public get ref(): string {
+    throw new Error(`Ref: ${this.logicalId} cannot be referenced`);
+  }
+
+  public hasProp(property: string): any {
+    return (
+      typeof this.instance === 'object' &&
+      this.instance[property as keyof Construct]
+    );
+  }
+}
+
+export class CfnResourceReference extends InstanceReference {
+  public hasAtt(_attribute: string): boolean {
+    /**
+     * @todo At the moment we cannot check if a CfnResource has an attribute.
+     * We would need to use L1 proper for this and could then do something like:
+     * return (
+     *   typeof this.instance === 'object' &&
+     *   Object.prototype.hasOwnProperty.call(this.instance, 'attr' + attribute)
+     * );
+    );
+     */
+    return true;
+  }
+}
+
+export class ConstructReference extends InstanceReference {
+  public constructor(id: string, public readonly instance: Construct) {
+    super(id, instance);
+  }
+
+  private get defaultChild(): cdk.CfnElement {
+    return this.instance.node?.defaultChild as cdk.CfnElement;
+  }
+
+  public get ref(): string {
+    return this.defaultChild?.logicalId;
+  }
+
+  public hasAtt(attribute: string): boolean {
+    return (
+      typeof this.defaultChild === 'object' &&
+      Object.prototype.hasOwnProperty.call(
+        this.defaultChild,
+        'attr' + attribute
+      )
+    );
+  }
+
+  public hasProp(property: string): any {
+    return (
+      typeof this.instance === 'object' &&
+      this.instance[property as keyof Construct]
+    );
+  }
+}

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -46,6 +46,7 @@ export interface ObjectLiteral extends ObjectExpression<TemplateExpression> {}
 export type IntrinsicExpression =
   | RefIntrinsic
   | GetAttIntrinsic
+  | GetPropIntrinsic
   | Base64Intrinsic
   | CidrIntrinsic
   | FindInMapIntrinsic
@@ -73,6 +74,13 @@ export interface GetAttIntrinsic {
   readonly fn: 'getAtt';
   readonly logicalId: string;
   readonly attribute: TemplateExpression;
+}
+
+export interface GetPropIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'getProp';
+  readonly logicalId: string;
+  readonly property: string;
 }
 
 export interface Base64Intrinsic {
@@ -238,6 +246,18 @@ export function parseExpression(x: unknown): TemplateExpression {
         fn: 'getAtt',
         logicalId: assertString(xs[0]),
         attribute: parseExpression(xs[1]),
+      };
+    },
+    'CDK::GetProp': (value) => {
+      if (typeof value == 'string') {
+        value = value.split('.');
+      }
+      const xs = assertList(value, [2]);
+      return {
+        type: 'intrinsic',
+        fn: 'getProp',
+        logicalId: assertString(xs[0]),
+        property: assertString(xs[1]),
       };
     },
     'Fn::Base64': (value) => ({

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -97,6 +97,7 @@ function findReferencedLogicalIds(
         switch (x.fn) {
           case 'ref':
           case 'getAtt':
+          case 'getProp':
             into.push(x.logicalId);
             break;
           case 'base64':

--- a/src/schema/cdk-intrinsics.ts
+++ b/src/schema/cdk-intrinsics.ts
@@ -1,0 +1,39 @@
+import { $ref } from './expression';
+import { schemaForIntrinsic } from './intrinsics';
+
+export const FnGetProp = () => {
+  const description =
+    'The CDK::GetProp intrinsic function returns the value of a Property from a Construct in the template. For more information about GetProp return values for a particular Construct, refer to the CDK documentation for that Construct in the Properties section.';
+  return {
+    anyOf: [
+      schemaForIntrinsic('CDK::GetProp', {
+        description,
+        params: [
+          {
+            name: 'logicalNameOfConstruct',
+            description:
+              'The logical name (also called logical ID) of the Construct that contains the Property that you want.',
+            types: [$ref('StringLiteral')],
+          },
+          {
+            name: 'propertyName',
+            description:
+              "The name of the Construct-specific Property whose value you want. See the Construct's documentation page for details about the Properties available.",
+            types: [$ref('StringLiteral')],
+          },
+        ],
+      }),
+      schemaForIntrinsic('CDK::GetProp', {
+        description,
+        params: [
+          {
+            name: 'shortSyntaxForm',
+            description:
+              'The logical name and property name in short syntax form: `logicalNameOfConstruct.propertyName`.',
+            types: [$ref('StringLiteral')],
+          },
+        ],
+      }),
+    ],
+  };
+};

--- a/src/schema/expression.ts
+++ b/src/schema/expression.ts
@@ -23,79 +23,56 @@ const DateLiteral = () => ({
   format: 'date-time',
 });
 
-const PrimitiveLiteral = (ctx: SchemaContext) => ({
-  $comment: 'A literal value',
-  anyOf: [
-    ctx.define('StringLiteral', StringLiteral),
-    ctx.define('NumberLiteral', NumberLiteral),
-    ctx.define('BooleanLiteral', BooleanLiteral),
-    ctx.define('DateLiteral', DateLiteral),
-  ],
-});
-
-const StringExpression = () => ({
-  $comment: 'Intrinsic function token expression or literal string value',
-  type: ['string', 'object'],
-  anyOf: [
-    $ref('StringLiteral'),
-    $ref('FnRef'),
-    $ref('FnBase64'),
-    $ref('FnFindInMap'),
-    $ref('FnGetAtt'),
-    $ref('FnImportValue'),
-    $ref('FnJoin'),
-    $ref('FnSelect'),
-    $ref('FnSub'),
-    $ref('FnIf'),
-  ],
-});
-
-const NumberExpression = () => ({
-  $comment: 'Intrinsic function token expression or literal number value',
-  type: ['number', 'object'],
-  anyOf: [
-    $ref('NumberLiteral'),
-    $ref('FnRef'),
-    $ref('FnFindInMap'),
-    $ref('FnGetAtt'),
-    $ref('FnImportValue'),
-    $ref('FnSelect'),
-    $ref('FnIf'),
-  ],
-});
-
-const BooleanExpression = () => ({
-  $comment: 'Intrinsic function token expression or literal boolean value',
-  type: ['boolean', 'object'],
-  anyOf: [
-    $ref('BooleanLiteral'),
-    $ref('FnRef'),
-    $ref('FnFindInMap'),
-    $ref('FnGetAtt'),
-    $ref('FnImportValue'),
-    $ref('FnSelect'),
-    $ref('FnIf'),
-  ],
-});
-
-const ListExpression = () => ({
-  $comment: 'Intrinsic function returning a list',
-  type: ['object'],
-  anyOf: [
-    $ref('FnRef'),
-    $ref('FnCidr'),
-    $ref('FnFindInMap'),
-    $ref('FnGetAtt'),
-    $ref('FnGetAZs'),
-    $ref('FnIf'),
-    $ref('FnSplit'),
-  ],
-});
-
-export function schemaForExpressions(ctx: SchemaContext) {
-  ctx.define('PrimitiveLiteral', PrimitiveLiteral);
-  ctx.define('StringExpression', StringExpression);
-  ctx.define('NumberExpression', NumberExpression);
-  ctx.define('BooleanExpression', BooleanExpression);
-  ctx.define('ListExpression', ListExpression);
+export function schemaForExpressions(
+  ctx: SchemaContext,
+  supportedIntrinsicFunctions: {
+    string: string[];
+    number: string[];
+    boolean: string[];
+    list: string[];
+  } = {
+    string: [],
+    number: [],
+    boolean: [],
+    list: [],
+  }
+) {
+  ctx.define('PrimitiveLiteral', () => ({
+    $comment: 'A literal value',
+    anyOf: [
+      ctx.define('StringLiteral', StringLiteral),
+      ctx.define('NumberLiteral', NumberLiteral),
+      ctx.define('BooleanLiteral', BooleanLiteral),
+      ctx.define('DateLiteral', DateLiteral),
+    ],
+  }));
+  ctx.define('StringExpression', () => ({
+    $comment: 'Intrinsic function token expression or literal string value',
+    type: ['string', 'object'],
+    anyOf: [
+      $ref('StringLiteral'),
+      ...supportedIntrinsicFunctions.string.map($ref),
+    ],
+  }));
+  ctx.define('NumberExpression', () => ({
+    $comment: 'Intrinsic function token expression or literal number value',
+    type: ['number', 'object'],
+    anyOf: [
+      $ref('NumberLiteral'),
+      ...supportedIntrinsicFunctions.number.map($ref),
+    ],
+  }));
+  ctx.define('BooleanExpression', () => ({
+    $comment: 'Intrinsic function token expression or literal boolean value',
+    type: ['boolean', 'object'],
+    anyOf: [
+      $ref('BooleanLiteral'),
+      ...supportedIntrinsicFunctions.boolean.map($ref),
+    ],
+  }));
+  ctx.define('ListExpression', () => ({
+    $comment: 'Intrinsic function returning a list',
+    type: ['object'],
+    anyOf: supportedIntrinsicFunctions.list.map($ref),
+  }));
 }

--- a/src/schema/intrinsics.ts
+++ b/src/schema/intrinsics.ts
@@ -1,3 +1,4 @@
+import { FnGetProp } from './cdk-intrinsics';
 import { ConditionExpression } from './conditions';
 import { $ref, schemaForExpressions } from './expression';
 import { SchemaContext } from './jsii2schema';
@@ -363,27 +364,71 @@ const FnRef = () => ({
   ),
 });
 
+const ANYS = {
+  FnRef,
+  FnFindInMap,
+  FnGetAtt,
+  FnGetProp,
+  FnIf,
+};
+
+const STRINGS = {
+  FnBase64,
+  FnImportValue,
+  FnJoin,
+  FnSelect,
+  FnSub,
+};
+
+const NUMBERS = {
+  FnImportValue,
+  FnSelect,
+};
+
+const BOOLEANS = {
+  FnImportValue,
+  FnSelect,
+};
+
+const LISTS = {
+  FnCidr,
+  FnGetAZs,
+  FnSplit,
+};
+
 export function schemaForIntrinsicFunctions(ctx: SchemaContext) {
-  schemaForExpressions(ctx);
+  const any = Object.keys(ANYS);
+  schemaForExpressions(ctx, {
+    string: Object.keys(STRINGS).concat(any),
+    number: Object.keys(NUMBERS).concat(any),
+    boolean: Object.keys(BOOLEANS).concat(any),
+    list: Object.keys(LISTS).concat(any),
+  });
+
+  const intrinsicFunctions: Record<string, (ctx: SchemaContext) => any> = {
+    FnBase64,
+    FnCidr,
+    FnFindInMap,
+    FnGetAtt,
+    FnGetProp,
+    FnGetAZs,
+    FnImportValue,
+    FnJoin,
+    FnSelect,
+    FnSplit,
+    FnSub,
+    FnTransform,
+    FnRef,
+    FnIf,
+  };
   ctx.define('IntrinsicExpression', () => ({
     $comment: 'Intrinsic function token expression',
     type: ['string'],
-    anyOf: [
-      ctx.define('FnBase64', FnBase64),
-      ctx.define('FnCidr', FnCidr),
-      ctx.define('FnFindInMap', FnFindInMap),
-      ctx.define('FnGetAtt', FnGetAtt),
-      ctx.define('FnGetAZs', FnGetAZs),
-      ctx.define('FnImportValue', FnImportValue),
-      ctx.define('FnJoin', FnJoin),
-      ctx.define('FnSelect', FnSelect),
-      ctx.define('FnSplit', FnSplit),
-      ctx.define('FnSub', FnSub),
-      ctx.define('FnTransform', FnTransform),
-      ctx.define('FnRef', FnRef),
-      ctx.define('FnIf', FnIf),
-    ],
+    anyOf: Object.entries(intrinsicFunctions).map(([name, fn]) =>
+      ctx.define(name, fn)
+    ),
   }));
+
   ctx.define('ConditionExpression', ConditionExpression);
 }
 

--- a/src/type-resolution/references.ts
+++ b/src/type-resolution/references.ts
@@ -1,6 +1,6 @@
 import { ParserError } from '../parser/private/types';
 import {
-  GetAttIntrinsic,
+  GetPropIntrinsic,
   RefIntrinsic,
   TemplateExpression,
 } from '../parser/template';
@@ -8,10 +8,10 @@ import { TypedTemplateExpression } from './expression';
 
 export interface ResolveReferenceExpression {
   type: 'resolve-reference';
-  reference: RefIntrinsic | GetAttIntrinsic;
+  reference: RefIntrinsic | GetPropIntrinsic;
 }
 
-export function resolveRef(x: RefIntrinsic): ResolveReferenceExpression {
+export function resolveRefToValue(x: RefIntrinsic): ResolveReferenceExpression {
   return {
     type: 'resolve-reference',
     reference: x,
@@ -30,7 +30,7 @@ export function refOrResolve(
   x: TemplateExpression,
   fn: (x: TemplateExpression) => TypedTemplateExpression
 ): TypedTemplateExpression {
-  if (x.type === 'intrinsic' && (x.fn === 'ref' || x.fn === 'getAtt')) {
+  if (x.type === 'intrinsic' && (x.fn === 'ref' || x.fn === 'getProp')) {
     return {
       type: 'resolve-reference',
       reference: x,

--- a/src/type-resolution/resolve.ts
+++ b/src/type-resolution/resolve.ts
@@ -32,7 +32,7 @@ import {
   resolveAnyExpression,
   resolveVoidExpression,
 } from './primitives';
-import { assertRef, refOrResolve, resolveRef } from './references';
+import { assertRef, refOrResolve, resolveRefToValue } from './references';
 import { isConstruct } from './resource-like';
 import { assertInterface, resolveStructExpression } from './struct';
 import { assertUnionOfTypes, resolveUnionOfTypesExpression } from './union';
@@ -91,7 +91,7 @@ export function resolveExpressionType(
       );
 
     case ResolvableExpressionType.CONSTRUCT:
-      return resolveRef(assertRef(x));
+      return resolveRefToValue(assertRef(x));
 
     case ResolvableExpressionType.ANY:
       return resolveAnyExpression(x);

--- a/test/evaluate/references.test.ts
+++ b/test/evaluate/references.test.ts
@@ -54,12 +54,12 @@ test('can use FnRef where it is expected to be evaluated to FnRef (not an object
                   Effect: 'Allow',
                   Action: ['s3:GetObject*', 's3:PutObject*'],
                   Resource: [
-                    { 'Fn::GetAtt': 'MyBucket.bucketArn' },
+                    { 'CDK::GetProp': 'MyBucket.bucketArn' },
                     { Ref: 'MyBucket' },
                     {
                       'Fn::Join': [
                         '',
-                        [{ 'Fn::GetAtt': 'MyBucket.bucketArn' }, '/*'],
+                        [{ 'Fn::GetAtt': 'MyBucket.Arn' }, '/*'],
                       ],
                     },
                     {

--- a/test/parser/intrinsics.test.ts
+++ b/test/parser/intrinsics.test.ts
@@ -1,0 +1,38 @@
+import { Template } from '../../src/parser/template';
+import '../util';
+
+test('FnGetProp', async () => {
+  // GIVEN
+  const template = await Template.fromObject({
+    Resources: {
+      Bucket: {
+        Type: 'aws-cdk-lib.aws_s3.Bucket',
+      },
+      Topic: {
+        Type: 'aws-cdk-lib.aws_sns.Topic',
+        Properties: {
+          displayName: { 'CDK::GetProp': ['Bucket', 'bucketName'] },
+          topicName: { 'CDK::GetProp': 'Bucket.bucketName' },
+        },
+      },
+    },
+  });
+
+  // THEN
+  const topic = template.resource('Topic');
+  expect(template.template).toBeValidTemplate();
+  expect(topic.properties).toMatchObject({
+    displayName: {
+      type: 'intrinsic',
+      fn: 'getProp',
+      logicalId: 'Bucket',
+      property: 'bucketName',
+    },
+    topicName: {
+      type: 'intrinsic',
+      fn: 'getProp',
+      logicalId: 'Bucket',
+      property: 'bucketName',
+    },
+  });
+});

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -38,12 +38,9 @@ TypedTemplate {
             },
             "resource": Object {
               "reference": Object {
-                "attribute": Object {
-                  "type": "string",
-                  "value": "root",
-                },
-                "fn": "getAtt",
+                "fn": "getProp",
                 "logicalId": "MyApi",
+                "property": "root",
                 "type": "intrinsic",
               },
               "type": "resolve-reference",
@@ -224,12 +221,9 @@ TypedTemplate {
             "value": "GET",
           },
           "resource": Object {
-            "attribute": Object {
-              "type": "string",
-              "value": "root",
-            },
-            "fn": "getAtt",
+            "fn": "getProp",
             "logicalId": "MyApi",
+            "property": "root",
             "type": "intrinsic",
           },
         },
@@ -245,7 +239,7 @@ TypedTemplate {
           "Properties": Object {
             "httpMethod": "GET",
             "resource": Object {
-              "Fn::GetAtt": "MyApi.root",
+              "CDK::GetProp": "MyApi.root",
             },
           },
           "Type": "aws-cdk-lib.aws_apigateway.Method",
@@ -1744,7 +1738,7 @@ TypedTemplate {
                                       Object {
                                         "attribute": Object {
                                           "type": "string",
-                                          "value": "bucketArn",
+                                          "value": "Arn",
                                         },
                                         "fn": "getAtt",
                                         "logicalId": "MyBucket",
@@ -1881,7 +1875,7 @@ TypedTemplate {
                                     Object {
                                       "attribute": Object {
                                         "type": "string",
-                                        "value": "bucketArn",
+                                        "value": "Arn",
                                       },
                                       "fn": "getAtt",
                                       "logicalId": "MyBucket",
@@ -1977,7 +1971,7 @@ TypedTemplate {
                           "",
                           Array [
                             Object {
-                              "Fn::GetAtt": "MyBucket.bucketArn",
+                              "Fn::GetAtt": "MyBucket.Arn",
                             },
                             "/*",
                           ],

--- a/test/type-resolution/references.test.ts
+++ b/test/type-resolution/references.test.ts
@@ -34,7 +34,7 @@ test('Constructs can be referenced', async () => {
       GetRoot: {
         Type: 'aws-cdk-lib.aws_apigateway.Method',
         Properties: {
-          resource: { 'Fn::GetAtt': ['MyApi', 'root'] },
+          resource: { 'CDK::GetProp': ['MyApi', 'root'] },
           httpMethod: 'GET',
         },
       },


### PR DESCRIPTION
Fixes #245 #268

--- 

Contains several changes:

- Refactor Json Schema for Intrinsics to be more dynamic
- Add `CDK::GetProp` JSON schema
- Refactor stack references to be more generic and support different types
- Change `Fn::GetAtt` to always operate on CFN Resources and always return a intrinsic function
- Add `CDK::GetProp` to get Object properties