### PR TITLE
feat: type inference

### DIFF
--- a/examples/method-calls.json
+++ b/examples/method-calls.json
@@ -42,6 +42,14 @@
           "aliasName": "live"
         }
       }
+    },
+    "ConfigureAsyncInvokeStatement": {
+      "On": "Alias",
+      "Call": {
+        "configureAsyncInvoke": {
+          "retryAttempts": 2
+        }
+      }
     }
   }
 }

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -32,8 +32,8 @@ export class Evaluator {
   public evaluateResource(resource: ResourceLike) {
     const construct = this.evaluate(resource);
 
-    // In case of method calls with void return type, the resource is
-    // just a syntactic feature, with nothing to evaluate to.
+    // If this is the result of a call to a method with no
+    // return type (void), then there is nothing else to do here.
     if (construct == null) return;
 
     this.applyTags(construct, resource.tags);

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -29,7 +29,7 @@ export class Evaluator {
     );
   }
 
-  public evaluateResource( resource: ResourceLike) {
+  public evaluateResource(resource: ResourceLike) {
     const construct = this.evaluate(resource);
 
     // In case of method calls with void return type, the resource is

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -24,11 +24,13 @@ export class Evaluator {
     );
   }
 
-  public evaluateResource(
-    logicalId: string,
-    resource: ResourceLike
-  ): IConstruct {
+  public evaluateResource(logicalId: string, resource: ResourceLike) {
     const construct = this.evaluate(resource);
+
+    // In case of method calls with void return type, the resource is
+    // just a syntactic feature, with nothing to evaluate to.
+    if (construct == null) return;
+
     this.applyTags(construct, resource.tags);
     this.applyDependsOn(construct, resource.dependsOn);
     if (isCdkConstructExpression(resource)) {
@@ -39,8 +41,6 @@ export class Evaluator {
       primaryValue: construct,
       attributes: construct,
     });
-
-    return construct;
   }
 
   public evaluate(x: TypedTemplateExpression): any {

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -1,6 +1,5 @@
 import {
   assertAtMostOneOfFields,
-  assertField,
   assertObject,
   assertString,
   assertStringOrList,
@@ -20,7 +19,7 @@ import { parseOverrides, ResourceOverride } from './overrides';
 import { parseTags, ResourceTag } from './tags';
 
 export interface TemplateResource {
-  readonly type: string;
+  readonly type?: string;
   readonly properties: Record<string, TemplateExpression>;
   readonly conditionName?: string;
   readonly dependencies: Set<string>;
@@ -49,11 +48,15 @@ export function parseTemplateResource(
 
   assertAtMostOneOfFields(resource, ['Properties', 'Call']);
 
+  if (resource.Properties != null && resource.Type == null) {
+    throw new Error(`In resource '${logicalId}': missing 'Type' property.`);
+  }
+
   const properties = parseObject(resource.Properties);
   const call = parseCall(resource.Call);
 
   return {
-    type: assertString(assertField(resource, 'Type')),
+    type: ifField(resource, 'Type', assertString),
     properties,
     conditionName: ifField(resource, 'Condition', assertString),
     metadata: assertObject(resource.Metadata ?? {}),

--- a/src/type-resolution/callables.ts
+++ b/src/type-resolution/callables.ts
@@ -1,4 +1,5 @@
 import * as reflect from 'jsii-reflect';
+import { TypeReference, TypeSystem } from 'jsii-reflect';
 import {
   assertExactlyOneOfFields,
   assertOneField,
@@ -29,30 +30,29 @@ export interface InstanceMethodCallExpression {
   readonly args: TypedArrayExpression;
 }
 
+interface MethodCall {
+  readonly method: reflect.Method;
+  readonly args: TypedArrayExpression;
+}
+
+interface InstanceMethodCall extends MethodCall {
+  readonly logicalId: string;
+}
+
 function methodFQN(method: reflect.Method): string {
   return `${method.parentType.fqn}.${method.name}`;
 }
 
 export function resolveStaticMethodCallExpression(
-  x: ObjectLiteral,
+  call: ObjectLiteral,
   typeSystem: reflect.TypeSystem,
   resultType?: reflect.Type
 ): StaticMethodCallExpression {
-  const candidateFQN = assertFullyQualifiedStaticMethodCall(x);
-  const candidateClass = typeSystem.findClass(candidateFQN);
-
-  const methods = enumLikeClassMethods(candidateClass);
-  const methodNames = methods.map(methodFQN);
-
-  const methodName = assertExactlyOneOfFields(x.fields, methodNames);
-  const method = methods.find((m) => methodFQN(m) === methodName)!;
+  const { method, args } = inferMethodCall(typeSystem, call);
 
   if (resultType) {
     assertImplements(method.returns.type, resultType);
   }
-
-  const parameters = assertExpressionType(x.fields[methodName], 'object');
-  const args = resolveCallableParameters(parameters, method);
 
   return {
     type: 'staticMethodCall',
@@ -69,46 +69,116 @@ export function resolveInstanceMethodCallExpression(
   typeSystem: reflect.TypeSystem,
   resultType?: reflect.Type
 ): InstanceMethodCallExpression {
-  const call = resource.call;
+  const { logicalId, method, args } = inferInstanceMethodCall(
+    typeSystem,
+    template,
+    resource
+  );
+
+  if (resultType) {
+    assertImplements(method.returns.type, resultType);
+  }
+
+  return {
+    type: 'instanceMethodCall',
+    logicalId,
+    method: method.name,
+    args,
+  };
+}
+
+function inferMethodCall(
+  typeSystem: reflect.TypeSystem,
+  call: ObjectLiteral
+): MethodCall {
+  const candidateFQN = assertFullyQualifiedStaticMethodCall(call);
+  const candidateClass = typeSystem.findClass(candidateFQN);
+  const methods = enumLikeClassMethods(candidateClass);
+  const methodNames = methods.map(methodFQN);
+  const methodName = assertExactlyOneOfFields(call.fields, methodNames);
+  const method = methods.find((m) => methodFQN(m) === methodName)!;
+  const parameters = assertExpressionType(call.fields[methodName], 'object');
+  const args = resolveCallableParameters(parameters, method);
+
+  return {
+    method,
+    args,
+  };
+}
+
+function inferInstanceMethodCall(
+  typeSystem: TypeSystem,
+  template: Template,
+  resource: TemplateResource
+): InstanceMethodCall {
   const logicalId = resource.on!;
   const factory = template.resource(logicalId);
-
   if (isCfnResource(factory)) {
     throw new Error(
       `${factory.type} is a CloudFormation resource. Method calls are not allowed.`
     );
   }
 
-  if (!factory.type) {
-    throw new Error('TODO'); //TODO
-  }
-
-  const candidateClass = typeSystem.findClass(factory.type);
-  const methods = candidateClass.allMethods.filter((m) => !m.static);
-  const methodNames = methods.map((method) => method.name);
-  const methodName = assertOneField(call.fields);
-
-  if (!methodNames.includes(methodName)) {
-    throw new Error(
-      `'${candidateClass.fqn}' has no method called '${methodName}'`
-    );
-  }
-
-  const method = methods.find((m) => m.name === methodName)!;
-
-  if (resultType) {
-    assertImplements(method.returns.type, resultType);
-  }
-
-  const parameters = assertExpressionType(call.fields[methodName], 'object');
+  const method = inferMethod(inferType(factory), resource.call);
+  const parameters = assertExpressionType(
+    resource.call.fields[method.name],
+    'object'
+  );
   const args = resolveCallableParameters(parameters, method);
 
   return {
-    type: 'instanceMethodCall',
     logicalId,
-    method: methodName,
+    method,
     args,
   };
+
+  function inferType(res: TemplateResource): TypeReference {
+    if (res.type) {
+      return typeSystem.findFqn(res.type).reference;
+    }
+
+    if (res.on) {
+      const typeReference = inferType(template.resource(res.on));
+      const m = inferMethod(typeReference, res.call);
+      return m.returns.type;
+    }
+
+    if (Object.keys(res.call.fields).length > 0) {
+      const methodCall = inferMethodCall(typeSystem, res.call);
+      return methodCall.method.returns.type;
+    }
+
+    throw new Error(
+      `The type of ${logicalId} could not be inferred. Please provide the type explicitly.`
+    );
+  }
+
+  function inferMethod(
+    typeRef: reflect.TypeReference,
+    call: ObjectLiteral
+  ): reflect.Method {
+    const candidateType = typeRef.type;
+    if (
+      !candidateType ||
+      !(candidateType.isClassType() || candidateType.isInterfaceType())
+    ) {
+      throw new Error(
+        `${logicalId} is neither a class nor an interface. Method calls are not allowed.`
+      );
+    }
+
+    const methods = candidateType.allMethods.filter((m) => !m.static);
+    const methodNames = methods.map((m) => m.name);
+    const methodName = assertOneField(call.fields);
+
+    if (!methodNames.includes(methodName)) {
+      throw new Error(
+        `'${candidateType.fqn}' has no method called '${methodName}'`
+      );
+    }
+
+    return methods.find((m) => m.name === methodName)!;
+  }
 }
 
 function assertFullyQualifiedStaticMethodCall(x: ObjectLiteral): string {

--- a/src/type-resolution/enums.ts
+++ b/src/type-resolution/enums.ts
@@ -29,6 +29,7 @@ export function resolveEnumLikeExpression(
 
   return resolveStaticMethodCallExpression(
     assertExpressionType(x, 'object'),
+    type.system,
     type
   );
 }

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -1954,7 +1954,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
+          "S3Key": "731f24951dbe4e08bfc519dd7c23a4f7158528bd5557e38437b08292ab2a873c.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2292,6 +2292,28 @@ Object {
         "Name": "live",
       },
       "Type": "AWS::Lambda::Alias",
+    },
+    "MyFunctionAliasliveEventInvokeConfig4F48E2E2": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "MyFunction3BAA72D1",
+        },
+        "MaximumRetryAttempts": 2,
+        "Qualifier": Object {
+          "Fn::Select": Array [
+            7,
+            Object {
+              "Fn::Split": Array [
+                ":",
+                Object {
+                  "Ref": "MyFunctionAliaslive8B92D042",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
     },
     "MyFunctionCurrentVersion197490AF4063a7e304a1f5a926b2da07afacb434": Object {
       "Properties": Object {

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -1954,7 +1954,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "731f24951dbe4e08bfc519dd7c23a4f7158528bd5557e38437b08292ab2a873c.zip",
+          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
         },
         "Description": "/opt/awscli/aws",
       },

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -2405,6 +2405,9 @@ TypedTemplate {
       "Alias" => Set {
         "MyFunction",
       },
+      "ConfigureAsyncInvokeStatement" => Set {
+        "Alias",
+      },
     },
     "keys": Set {
       "SourceBucket",
@@ -2412,6 +2415,7 @@ TypedTemplate {
       "MyFunction",
       "Grant",
       "Alias",
+      "ConfigureAsyncInvokeStatement",
     },
     "nodes": Object {
       "Alias": Object {
@@ -2434,7 +2438,6 @@ TypedTemplate {
           "type": "instanceMethodCall",
         },
         "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_lambda.Alias",
         "logicalId": "Alias",
         "namespace": "aws_lambda",
         "overrides": Array [],
@@ -2469,9 +2472,35 @@ TypedTemplate {
           "type": "staticMethodCall",
         },
         "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_lambda.Code",
         "logicalId": "BusinessLogic",
         "namespace": "aws_lambda",
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
+      "ConfigureAsyncInvokeStatement": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "fields": Object {
+                  "retryAttempts": Object {
+                    "type": "number",
+                    "value": 2,
+                  },
+                },
+                "type": "struct",
+              },
+            ],
+            "type": "array",
+          },
+          "logicalId": "Alias",
+          "method": "configureAsyncInvoke",
+          "type": "instanceMethodCall",
+        },
+        "dependsOn": Array [],
+        "logicalId": "ConfigureAsyncInvokeStatement",
+        "namespace": undefined,
         "overrides": Array [],
         "tags": Array [],
         "type": "lazyResource",
@@ -2499,7 +2528,6 @@ TypedTemplate {
           "type": "instanceMethodCall",
         },
         "dependsOn": Array [],
-        "fqn": "aws-cdk-lib.aws_iam.Grant",
         "logicalId": "Grant",
         "namespace": "aws_iam",
         "overrides": Array [],
@@ -2705,6 +2733,35 @@ TypedTemplate {
         "type": "aws-cdk-lib.aws_lambda.Alias",
         "updateReplacePolicy": "Delete",
       },
+      "ConfigureAsyncInvokeStatement" => Object {
+        "call": Object {
+          "fields": Object {
+            "configureAsyncInvoke": Object {
+              "fields": Object {
+                "retryAttempts": Object {
+                  "type": "number",
+                  "value": 2,
+                },
+              },
+              "type": "object",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "Alias",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": "Alias",
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": undefined,
+        "updateReplacePolicy": "Delete",
+      },
     },
     "template": Object {
       "$schema": "../cdk.schema.json",
@@ -2728,6 +2785,14 @@ TypedTemplate {
             },
           },
           "Type": "aws-cdk-lib.aws_lambda.Code",
+        },
+        "ConfigureAsyncInvokeStatement": Object {
+          "Call": Object {
+            "configureAsyncInvoke": Object {
+              "retryAttempts": 2,
+            },
+          },
+          "On": "Alias",
         },
         "Grant": Object {
           "Call": Object {


### PR DESCRIPTION
Making the type optional for lazy resources (defined by method calls). It will be inferred from the return type of the method. For instance methods, it's necessary to recursively look up the the type of the "factory resource" first. On this dependency chain, the type can be omitted on multiple resources and the lookup will stop at a base case.

For eager resources (defined by properties), the type declaration remains mandatory.