### PR TITLE
feat: FnSelect

### DIFF
--- a/src/schema/intrinsics.ts
+++ b/src/schema/intrinsics.ts
@@ -423,7 +423,7 @@ export function schemaForIntrinsicFunctions(ctx: SchemaContext) {
   };
   ctx.define('IntrinsicExpression', () => ({
     $comment: 'Intrinsic function token expression',
-    type: ['string'],
+    type: ['string', 'object'],
     anyOf: Object.entries(intrinsicFunctions).map(([name, fn]) =>
       ctx.define(name, fn)
     ),


### PR DESCRIPTION
Note that `Fn::Select` will **never** return a Construct object. Instead `Ref` will always return the ref to the default child.

Doing otherwise doesn't make a lot of sense, since there are two general cases with FnSelect:
- The index is a known value
- The index is only resolved server-side

In the first case of a known index, a user can just self-select and remove the select intrinsic.
In the second case of server-side resolution, we cannot represent the Construct anymore, so there is no point in attempting to reference it.