### PR TITLE
fix: FnGetProp can access underlying stack details

### DIFF
--- a/src/evaluate/references.ts
+++ b/src/evaluate/references.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { assertObject, ParserError } from '../parser/private/types';
 
@@ -8,6 +9,8 @@ function isPropertyOf(
 ): boolean {
   return (
     !path.startsWith('_') &&
+    !Stack.isStack(instance) &&
+    !Stage.isStage(instance) &&
     instance[path] !== undefined &&
     typeof instance[path] !== 'function'
   );

--- a/test/util.ts
+++ b/test/util.ts
@@ -3,7 +3,10 @@ import * as path from 'path';
 import { join } from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { DefaultStackSynthesizer } from 'aws-cdk-lib';
-import { Template as AssertionTemplate } from 'aws-cdk-lib/assertions';
+import {
+  Match as BaseMatch,
+  Template as AssertionTemplate,
+} from 'aws-cdk-lib/assertions';
 import * as reflect from 'jsii-reflect';
 import * as jsonschema from 'jsonschema';
 import { DeclarativeStack, loadTypeSystem } from '../src';
@@ -108,6 +111,12 @@ export function testExamples(
       }),
     timeout
   );
+}
+
+export class Match extends BaseMatch {
+  public static logicalIdFor(id: string) {
+    return Match.stringLikeRegexp(`^${id}.{8}$`);
+  }
 }
 
 declare global {


### PR DESCRIPTION
It's possible to break the app accessing stack directly. Best to just prevent it.