### PR TITLE
fix: all Mappings are incorrectly lists

### DIFF
--- a/src/parser/private/types.ts
+++ b/src/parser/private/types.ts
@@ -35,10 +35,7 @@ export function assertNumber(x: unknown): number {
   throw new ParserError(`Expected number, got: ${JSON.stringify(x)}`);
 }
 
-export function assertList<T = unknown>(
-  x: T[] | unknown,
-  lengths?: number[]
-): T[] | unknown[] {
+export function assertList<T = unknown>(x: unknown, lengths?: number[]): T[] {
   if (!Array.isArray(x)) {
     throw new ParserError(`Expected list, got: ${JSON.stringify(x)}`);
   }
@@ -150,7 +147,7 @@ export function assertOneField(xs: unknown): string {
   return fields[0];
 }
 
-export function assertStringOrList(x: unknown): string[] {
+export function assertStringOrListIntoList(x: unknown): string[] {
   if (typeof x === 'string') {
     return [x];
   }
@@ -193,5 +190,28 @@ export function mapFromObject<A>(
 ): Map<string, A> {
   return new Map(
     Object.entries(assertObject(xs)).map(([k, v]) => [k, fn(v as any)])
+  );
+}
+
+export function assertOr<T>(
+  x: unknown,
+  error: (v: string) => string,
+  ...assertions: Array<(e: unknown) => T>
+) {
+  for (const assertion of assertions) {
+    try {
+      return assertion(x);
+    } catch {}
+  }
+
+  throw new ParserError(error(JSON.stringify(x)));
+}
+
+export function assertStringOrStringList(xs: unknown): string | string[] {
+  return assertOr<string | string[]>(
+    xs,
+    (v) => `Expected string or list of strings, got: ${v}`,
+    assertString,
+    assertList
   );
 }

--- a/src/parser/template/mappings.ts
+++ b/src/parser/template/mappings.ts
@@ -1,4 +1,4 @@
-import { assertStringOrList, mapFromObject } from '../private/types';
+import { assertStringOrStringList, mapFromObject } from '../private/types';
 
 export class TemplateMapping {
   public constructor(
@@ -18,9 +18,8 @@ export class TemplateMapping {
     );
   }
 }
-
 export function parseMapping(xs: unknown): TemplateMapping {
   return new TemplateMapping(
-    mapFromObject(xs, (m) => mapFromObject(m, assertStringOrList))
+    mapFromObject(xs, (m) => mapFromObject(m, assertStringOrStringList))
   );
 }

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -2,7 +2,7 @@ import {
   assertAtMostOneOfFields,
   assertObject,
   assertString,
-  assertStringOrList,
+  assertStringOrListIntoList,
   parseRetentionPolicy,
   singletonList,
 } from '../private/types';
@@ -61,13 +61,13 @@ export function parseTemplateResource(
     conditionName: ifField(resource, 'Condition', assertString),
     metadata: assertObject(resource.Metadata ?? {}),
     dependencies: new Set([
-      ...(ifField(resource, 'DependsOn', assertStringOrList) ?? []),
+      ...(ifField(resource, 'DependsOn', assertStringOrListIntoList) ?? []),
       ...singletonList(ifField(resource, 'On', assertString)),
       ...findReferencedLogicalIds(properties),
       ...findReferencedLogicalIds({ _: call }),
     ]),
     dependsOn: new Set([
-      ...(ifField(resource, 'DependsOn', assertStringOrList) ?? []),
+      ...(ifField(resource, 'DependsOn', assertStringOrListIntoList) ?? []),
     ]),
     deletionPolicy:
       ifField(resource, 'DeletionPolicy', parseRetentionPolicy) ?? 'Delete',

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -1301,20 +1301,12 @@ Object {
   "Mappings": Object {
     "RegionMap": Object {
       "eu-west-1": Object {
-        "HVM64": Array [
-          "ami-047bb4163c506cd98",
-        ],
-        "HVMG2": Array [
-          "ami-0a7c483d527806435",
-        ],
+        "HVM64": "ami-047bb4163c506cd98",
+        "HVMG2": "ami-0a7c483d527806435",
       },
       "us-west-1": Object {
-        "HVM64": Array [
-          "ami-0bdb828fd58c52235",
-        ],
-        "HVMG2": Array [
-          "ami-066ee5fd4a9ef77f1",
-        ],
+        "HVM64": "ami-0bdb828fd58c52235",
+        "HVMG2": "ami-066ee5fd4a9ef77f1",
       },
     },
   },

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -1,6 +1,110 @@
 import { Template } from '../../src/parser/template';
 import { Testing } from '../util';
 
+describe('Mappings', () => {
+  test('can use Mapping with string value', async () => {
+    // GIVEN
+    const template = await Testing.template(
+      await Template.fromObject({
+        Mappings: {
+          RegionMap: {
+            'us-west-1': {
+              HVM64: 'ami-0bdb828fd58c52235',
+              HVMG2: 'ami-066ee5fd4a9ef77f1',
+            },
+            'eu-west-1': {
+              HVM64: 'ami-047bb4163c506cd98',
+              HVMG2: 'ami-0a7c483d527806435',
+            },
+          },
+        },
+        Resources: {
+          myEC2Instance: {
+            Type: 'AWS::EC2::Instance',
+            Properties: {
+              ImageId: {
+                'Fn::FindInMap': ['RegionMap', { Ref: 'AWS::Region' }, 'HVM64'],
+              },
+              InstanceType: 'm1.small',
+            },
+          },
+        },
+      })
+    );
+
+    // THEN
+    template.hasMapping('RegionMap', {
+      'us-west-1': {
+        HVM64: 'ami-0bdb828fd58c52235',
+        HVMG2: 'ami-066ee5fd4a9ef77f1',
+      },
+      'eu-west-1': {
+        HVM64: 'ami-047bb4163c506cd98',
+        HVMG2: 'ami-0a7c483d527806435',
+      },
+    });
+    template.hasResourceProperties('AWS::EC2::Instance', {
+      ImageId: {
+        'Fn::FindInMap': ['RegionMap', { Ref: 'AWS::Region' }, 'HVM64'],
+      },
+    });
+  });
+
+  test('can use Mapping with list value', async () => {
+    // GIVEN
+    const template = await Testing.template(
+      await Template.fromObject({
+        Mappings: {
+          RegionMap: {
+            'eu-west-1': {
+              HVM64: ['ami-047bb4163c506cd98'],
+              HVMG2: ['ami-0a7c483d527806435'],
+            },
+          },
+        },
+        Resources: {
+          myEC2Instance: {
+            Type: 'AWS::EC2::Instance',
+            Properties: {
+              ImageId: {
+                'Fn::Select': [
+                  0,
+                  {
+                    'Fn::FindInMap': [
+                      'RegionMap',
+                      { Ref: 'AWS::Region' },
+                      'HVM64',
+                    ],
+                  },
+                ],
+              },
+              InstanceType: 'm1.small',
+            },
+          },
+        },
+      })
+    );
+
+    // THEN
+    template.hasMapping('RegionMap', {
+      'eu-west-1': {
+        HVM64: ['ami-047bb4163c506cd98'],
+        HVMG2: ['ami-0a7c483d527806435'],
+      },
+    });
+    template.hasResourceProperties('AWS::EC2::Instance', {
+      ImageId: {
+        'Fn::Select': [
+          0,
+          {
+            'Fn::FindInMap': ['RegionMap', { Ref: 'AWS::Region' }, 'HVM64'],
+          },
+        ],
+      },
+    });
+  });
+});
+
 describe('given a template with unknown top-level properties', () => {
   it('can synth the template and will ignore unknown properties', async () => {
     // GIVEN

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -893,20 +893,12 @@ TypedTemplate {
     "RegionMap" => TemplateMapping {
       "mapping": Map {
         "us-west-1" => Map {
-          "HVM64" => Array [
-            "ami-0bdb828fd58c52235",
-          ],
-          "HVMG2" => Array [
-            "ami-066ee5fd4a9ef77f1",
-          ],
+          "HVM64" => "ami-0bdb828fd58c52235",
+          "HVMG2" => "ami-066ee5fd4a9ef77f1",
         },
         "eu-west-1" => Map {
-          "HVM64" => Array [
-            "ami-047bb4163c506cd98",
-          ],
-          "HVMG2" => Array [
-            "ami-0a7c483d527806435",
-          ],
+          "HVM64" => "ami-047bb4163c506cd98",
+          "HVMG2" => "ami-0a7c483d527806435",
         },
       },
     },
@@ -978,20 +970,12 @@ TypedTemplate {
       "RegionMap" => TemplateMapping {
         "mapping": Map {
           "us-west-1" => Map {
-            "HVM64" => Array [
-              "ami-0bdb828fd58c52235",
-            ],
-            "HVMG2" => Array [
-              "ami-066ee5fd4a9ef77f1",
-            ],
+            "HVM64" => "ami-0bdb828fd58c52235",
+            "HVMG2" => "ami-066ee5fd4a9ef77f1",
           },
           "eu-west-1" => Map {
-            "HVM64" => Array [
-              "ami-047bb4163c506cd98",
-            ],
-            "HVMG2" => Array [
-              "ami-0a7c483d527806435",
-            ],
+            "HVM64" => "ami-047bb4163c506cd98",
+            "HVMG2" => "ami-0a7c483d527806435",
           },
         },
       },


### PR DESCRIPTION
Given the following template:
```yaml
Mappings:
  RegionMap:
    us-west-1:
      HVM64: ami-0bdb828fd58c52235
```

This previously resulted in this template:

```yaml
Mappings:
  RegionMap:
    us-west-1:
      HVM64:
        - ami-0bdb828fd58c52235    # <--- This should not be a list
```

Now correctly keeps the Mapping value as string.