### PR TITLE
feat: fromXxx() methods can be called with implicit or explicit parameters

### DIFF
--- a/examples/method-calls.json
+++ b/examples/method-calls.json
@@ -26,11 +26,40 @@
         }
       }
     },
-    "Grant": {
-      "Type": "aws-cdk-lib.aws_iam.Grant",
-      "On": "SourceBucket",
+    "ReadBucket": {
       "Call": {
-        "grantRead": {"Ref": "MyFunction"}
+        "aws-cdk-lib.aws_s3.Bucket.fromBucketName": "read-bucket"
+      }
+    },
+    "GrantRead": {
+      "Type": "aws-cdk-lib.aws_iam.Grant",
+      "On": "ReadBucket",
+      "Call": {
+        "grantRead": {
+          "Ref": "MyFunction"
+        }
+      }
+    },
+    "WriteBucket": {
+      "Call": {
+        "aws-cdk-lib.aws_s3.Bucket.fromBucketName": {
+          "CDK::Args": [
+            {
+              "Ref": "CDK::Scope"
+            },
+            "WriteBucket",
+            "write-bucket"
+          ]
+        }
+      }
+    },
+    "GrantWrite": {
+      "Type": "aws-cdk-lib.aws_iam.Grant",
+      "On": "WriteBucket",
+      "Call": {
+        "grantWrite": {
+          "Ref": "MyFunction"
+        }
       }
     },
     "Alias": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "json-schema": "^0.4.0",
     "npm-check-updates": "^15",
     "prettier": "^2.7.1",
-    "projen": "^0.62.19",
+    "projen": "^0.62.21",
     "standard-version": "^9",
     "ts-jest": "^27",
     "ts-node": "^10.9.1",

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -20,6 +20,7 @@ import {
   getPropDot,
   ValueOnlyReference,
 } from './references';
+
 export class Evaluator {
   constructor(public readonly context: EvaluationContext) {}
 
@@ -133,6 +134,8 @@ export class Evaluator {
             return this.fnNot(assertBoolean(ev(x.operand)));
           case 'equals':
             return this.fnEquals(ev(x.value1), ev(x.value2));
+          case 'args':
+            return this.evaluateArray(x.array);
         }
       case 'enum':
         return this.enum(x.fqn, x.choice);
@@ -288,6 +291,11 @@ export class Evaluator {
 
   protected resolveReferences(intrinsic: RefIntrinsic | GetPropIntrinsic) {
     const { logicalId, fn } = intrinsic;
+
+    if (logicalId === 'CDK::Scope') {
+      return this.context.stack;
+    }
+
     const c = this.context.reference(logicalId);
 
     if (fn !== 'ref') {

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -61,7 +61,8 @@ export type IntrinsicExpression =
   | AndIntrinsic
   | OrIntrinsic
   | NotIntrinsic
-  | EqualsIntrinsic;
+  | EqualsIntrinsic
+  | ArgsIntrinsic;
 
 export interface RefIntrinsic {
   readonly type: 'intrinsic';
@@ -183,6 +184,12 @@ export interface EqualsIntrinsic {
   readonly fn: 'equals';
   readonly value1: TemplateExpression;
   readonly value2: TemplateExpression;
+}
+
+export interface ArgsIntrinsic {
+  readonly type: 'intrinsic';
+  readonly fn: 'args';
+  readonly array: TemplateExpression[];
 }
 
 export function isExpression(x: unknown): x is TemplateExpression {
@@ -395,6 +402,13 @@ export function parseExpression(x: unknown): TemplateExpression {
         fn: 'equals',
         value1: parseExpression(x1),
         value2: parseExpression(x2),
+      };
+    },
+    'CDK::Args': (value) => {
+      return {
+        type: 'intrinsic',
+        fn: 'args',
+        array: assertList(value).map(parseExpression),
       };
     },
   };

--- a/src/parser/template/resource.ts
+++ b/src/parser/template/resource.ts
@@ -40,6 +40,11 @@ export function parseTemplateResource(
   logicalId: string,
   resource: schema.Resource
 ): TemplateResource {
+  if (!/^[A-Za-z0-9]+$/.test(logicalId)) {
+    throw new Error(
+      `Resource logical IDs must be alphanumeric. Got: '${logicalId}'.`
+    );
+  }
   if (resource.On != null && resource.Call == null) {
     throw new Error(
       `In resource '${logicalId}': expected to find a 'Call' property, to a method of '${resource.On}'.`
@@ -142,6 +147,9 @@ function findReferencedLogicalIds(
             break;
           case 'transform':
             Object.values(x.parameters).forEach(recurse);
+            break;
+          case 'args':
+            x.array.forEach(recurse);
             break;
           default:
             throw new Error(`Unrecognized intrinsic for evaluation: ${x.fn}`);

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -648,6 +648,12 @@ export function isEnumLikeClass(
   );
 }
 
+export function staticNonVoidMethods(cls: jsiiReflect.ClassType) {
+  return cls.allMethods.filter(
+    (m) => m.static && m.returns && m.returns.type.type
+  );
+}
+
 export function enumLikeClassMethods(cls: jsiiReflect.ClassType) {
   return cls.allMethods.filter(
     (m) =>

--- a/src/type-resolution/resolve.ts
+++ b/src/type-resolution/resolve.ts
@@ -162,11 +162,11 @@ export function analyzeTypeReference(
   if (isEnumLikeClass(typeRef.type)) {
     return ResolvableExpressionType.ENUM_LIKE_CLASS;
   }
-  if (isSerializableInterface(typeRef.type)) {
-    return ResolvableExpressionType.STRUCT;
-  }
   if (isBehavioralInterface(typeRef.type)) {
     return ResolvableExpressionType.BEHAVIORAL_INTERFACE;
+  }
+  if (isSerializableInterface(typeRef.type)) {
+    return ResolvableExpressionType.STRUCT;
   }
   if (isConstruct(typeRef.type)) {
     return ResolvableExpressionType.CONSTRUCT;

--- a/src/type-resolution/resource-like.ts
+++ b/src/type-resolution/resource-like.ts
@@ -78,7 +78,12 @@ function resolveLazyResource(
 ): LazyResource {
   const call = resource.on
     ? resolveInstanceMethodCallExpression(template, resource, typeSystem, type)
-    : resolveStaticMethodCallExpression(resource.call, typeSystem, type);
+    : resolveStaticMethodCallExpression(
+        resource.call,
+        typeSystem,
+        type,
+        logicalId
+      );
 
   return {
     type: 'lazyResource',

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -3144,22 +3144,64 @@ Object {
               "Effect": "Allow",
               "Resource": Array [
                 Object {
-                  "Fn::GetAtt": Array [
-                    "SourceBucketDDD2130A",
-                    "Arn",
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::read-bucket",
+                    ],
                   ],
                 },
                 Object {
                   "Fn::Join": Array [
                     "",
                     Array [
+                      "arn:",
                       Object {
-                        "Fn::GetAtt": Array [
-                          "SourceBucketDDD2130A",
-                          "Arn",
-                        ],
+                        "Ref": "AWS::Partition",
                       },
-                      "/*",
+                      ":s3:::read-bucket/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::write-bucket",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::write-bucket/*",
                     ],
                   ],
                 },

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -3196,8 +3196,14 @@ TypedTemplate {
       "MyFunction" => Set {
         "BusinessLogic",
       },
-      "Grant" => Set {
-        "SourceBucket",
+      "ReadBucket" => Set {},
+      "GrantRead" => Set {
+        "ReadBucket",
+        "MyFunction",
+      },
+      "WriteBucket" => Set {},
+      "GrantWrite" => Set {
+        "WriteBucket",
         "MyFunction",
       },
       "Alias" => Set {
@@ -3209,9 +3215,12 @@ TypedTemplate {
     },
     "keys": Set {
       "SourceBucket",
+      "ReadBucket",
+      "WriteBucket",
       "BusinessLogic",
       "MyFunction",
-      "Grant",
+      "GrantRead",
+      "GrantWrite",
       "Alias",
       "ConfigureAsyncInvokeStatement",
     },
@@ -3302,7 +3311,7 @@ TypedTemplate {
         "tags": Array [],
         "type": "lazyResource",
       },
-      "Grant": Object {
+      "GrantRead": Object {
         "call": Object {
           "args": Object {
             "array": Array [
@@ -3320,12 +3329,41 @@ TypedTemplate {
             ],
             "type": "array",
           },
-          "logicalId": "SourceBucket",
+          "logicalId": "ReadBucket",
           "method": "grantRead",
           "type": "instanceMethodCall",
         },
         "dependsOn": Array [],
-        "logicalId": "Grant",
+        "logicalId": "GrantRead",
+        "namespace": "aws_iam",
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
+      "GrantWrite": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "reference": Object {
+                  "fn": "ref",
+                  "logicalId": "MyFunction",
+                  "type": "intrinsic",
+                },
+                "type": "resolve-reference",
+              },
+              Object {
+                "type": "void",
+              },
+            ],
+            "type": "array",
+          },
+          "logicalId": "WriteBucket",
+          "method": "grantWrite",
+          "type": "instanceMethodCall",
+        },
+        "dependsOn": Array [],
+        "logicalId": "GrantWrite",
         "namespace": "aws_iam",
         "overrides": Array [],
         "tags": Array [],
@@ -3363,6 +3401,41 @@ TypedTemplate {
         "tags": Array [],
         "type": "construct",
       },
+      "ReadBucket": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "reference": Object {
+                  "fn": "ref",
+                  "logicalId": "CDK::Scope",
+                  "type": "intrinsic",
+                },
+                "type": "resolve-reference",
+              },
+              Object {
+                "type": "string",
+                "value": "ReadBucket",
+              },
+              Object {
+                "type": "string",
+                "value": "read-bucket",
+              },
+            ],
+            "type": "array",
+          },
+          "fqn": "aws-cdk-lib.aws_s3.Bucket",
+          "method": "fromBucketName",
+          "namespace": "aws_s3",
+          "type": "staticMethodCall",
+        },
+        "dependsOn": Array [],
+        "logicalId": "ReadBucket",
+        "namespace": undefined,
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
+      },
       "SourceBucket": Object {
         "dependsOn": Array [],
         "fqn": "aws-cdk-lib.aws_s3.Bucket",
@@ -3375,6 +3448,41 @@ TypedTemplate {
         },
         "tags": Array [],
         "type": "construct",
+      },
+      "WriteBucket": Object {
+        "call": Object {
+          "args": Object {
+            "array": Array [
+              Object {
+                "reference": Object {
+                  "fn": "ref",
+                  "logicalId": "CDK::Scope",
+                  "type": "intrinsic",
+                },
+                "type": "resolve-reference",
+              },
+              Object {
+                "type": "string",
+                "value": "WriteBucket",
+              },
+              Object {
+                "type": "string",
+                "value": "write-bucket",
+              },
+            ],
+            "type": "array",
+          },
+          "fqn": "aws-cdk-lib.aws_s3.Bucket",
+          "method": "fromBucketName",
+          "namespace": "aws_s3",
+          "type": "staticMethodCall",
+        },
+        "dependsOn": Array [],
+        "logicalId": "WriteBucket",
+        "namespace": undefined,
+        "overrides": Array [],
+        "tags": Array [],
+        "type": "lazyResource",
       },
     },
   },
@@ -3471,7 +3579,29 @@ TypedTemplate {
         "type": "aws-cdk-lib.aws_lambda.Function",
         "updateReplacePolicy": "Delete",
       },
-      "Grant" => Object {
+      "ReadBucket" => Object {
+        "call": Object {
+          "fields": Object {
+            "aws-cdk-lib.aws_s3.Bucket.fromBucketName": Object {
+              "type": "string",
+              "value": "read-bucket",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {},
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": undefined,
+        "updateReplacePolicy": "Delete",
+      },
+      "GrantRead" => Object {
         "call": Object {
           "fields": Object {
             "grantRead": Object {
@@ -3485,12 +3615,77 @@ TypedTemplate {
         "conditionName": undefined,
         "deletionPolicy": "Delete",
         "dependencies": Set {
-          "SourceBucket",
+          "ReadBucket",
           "MyFunction",
         },
         "dependsOn": Set {},
         "metadata": Object {},
-        "on": "SourceBucket",
+        "on": "ReadBucket",
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_iam.Grant",
+        "updateReplacePolicy": "Delete",
+      },
+      "WriteBucket" => Object {
+        "call": Object {
+          "fields": Object {
+            "aws-cdk-lib.aws_s3.Bucket.fromBucketName": Object {
+              "array": Array [
+                Object {
+                  "fn": "ref",
+                  "logicalId": "CDK::Scope",
+                  "type": "intrinsic",
+                },
+                Object {
+                  "type": "string",
+                  "value": "WriteBucket",
+                },
+                Object {
+                  "type": "string",
+                  "value": "write-bucket",
+                },
+              ],
+              "fn": "args",
+              "type": "intrinsic",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "CDK::Scope",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {},
+        "tags": Array [],
+        "type": undefined,
+        "updateReplacePolicy": "Delete",
+      },
+      "GrantWrite" => Object {
+        "call": Object {
+          "fields": Object {
+            "grantWrite": Object {
+              "fn": "ref",
+              "logicalId": "MyFunction",
+              "type": "intrinsic",
+            },
+          },
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "WriteBucket",
+          "MyFunction",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": "WriteBucket",
         "overrides": Array [],
         "properties": Object {},
         "tags": Array [],
@@ -3588,13 +3783,22 @@ TypedTemplate {
           },
           "On": "Alias",
         },
-        "Grant": Object {
+        "GrantRead": Object {
           "Call": Object {
             "grantRead": Object {
               "Ref": "MyFunction",
             },
           },
-          "On": "SourceBucket",
+          "On": "ReadBucket",
+          "Type": "aws-cdk-lib.aws_iam.Grant",
+        },
+        "GrantWrite": Object {
+          "Call": Object {
+            "grantWrite": Object {
+              "Ref": "MyFunction",
+            },
+          },
+          "On": "WriteBucket",
           "Type": "aws-cdk-lib.aws_iam.Grant",
         },
         "MyFunction": Object {
@@ -3607,8 +3811,26 @@ TypedTemplate {
           },
           "Type": "aws-cdk-lib.aws_lambda.Function",
         },
+        "ReadBucket": Object {
+          "Call": Object {
+            "aws-cdk-lib.aws_s3.Bucket.fromBucketName": "read-bucket",
+          },
+        },
         "SourceBucket": Object {
           "Type": "aws-cdk-lib.aws_s3.Bucket",
+        },
+        "WriteBucket": Object {
+          "Call": Object {
+            "aws-cdk-lib.aws_s3.Bucket.fromBucketName": Object {
+              "CDK::Args": Array [
+                Object {
+                  "Ref": "CDK::Scope",
+                },
+                "WriteBucket",
+                "write-bucket",
+              ],
+            },
+          },
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,9 +2115,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.251:
-  version "1.4.261"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.261.tgz#31f14ad60c6f95bec404a77a2fd5e1962248e112"
-  integrity sha512-fVXliNUGJ7XUVJSAasPseBbVgJIeyw5M1xIkgXdTSRjlmCqBbiSTsEdLOCJS31Fc8B7CaloQ/BFAg8By3ODLdg==
+  version "1.4.262"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz#25715dfbae4c2e0640517cba184715241ecd8e63"
+  integrity sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -4897,10 +4897,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.62.19:
-  version "0.62.19"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.62.19.tgz#c9f93ce649730a626edfcd8c0c344d50921fe95d"
-  integrity sha512-gViJ0dGdTQx/xPF0hlu4ClLdjdwF52m/lPLM+CI3LbjJyOayoXUo6INXtRCBnyWXCbixhdYQH2Uwu+ZaCLBY5g==
+projen@^0.62.21:
+  version "0.62.21"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.62.21.tgz#7111191d0b5f11ae9cfa8c0e6cf4ab2197c38948"
+  integrity sha512-kBHbVswJbqggBkDVERuHntKura8z7vsjgLYp2rvesYSZSA4fvWbIr4pW+9g9cWQf0Wg+ST1lNx1Eois6ei15sw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Static factory methods with a [“from” prefix][1] allow users to import unowned constructs. Awslint enforces the rules that the first two arguments are the scope and id, followed by the parameters specific to the method.

With this change, users can call methods of this category, by either omitting the scope and id:

```json
"Call": {
  "aws-cdk-lib.aws_s3.Bucket.fromBucketName": "read-bucket"
}
```

or by passing them explicitly using a new CDK-specific intrinsic function, `CDK::Args`, along with a new CDK-specific pseudo-parameter, `CDK::Scope`:

```json
"Call": {
  "aws-cdk-lib.aws_s3.Bucket.fromBucketName": {
    "CDK::Args": [{ "Ref": "CDK::Scope" }, "ReadBucket", "read-bucket"]
  }
}
```

[1]: https://github.com/aws/aws-cdk/blob/v1-main/docs/DESIGN_GUIDELINES.md#imports