### PR TITLE
fix: allow and test `'true'` in `NoEcho`, explicitly test string to number conversion

### DIFF
--- a/src/parser/template/parameters.ts
+++ b/src/parser/template/parameters.ts
@@ -28,6 +28,8 @@ export function parseParameter(x: unknown): TemplateParameter {
     maxValue: ifField(param, 'MaxValue', assertNumber),
     minLength: ifField(param, 'MinLength', assertNumber),
     minValue: ifField(param, 'MinValue', assertNumber),
-    noEcho: ifField(param, 'NoEcho', assertBoolean),
+    noEcho: ifField(param, 'NoEcho', (v: unknown) => {
+      return v === 'true' ? true : assertBoolean(v);
+    }),
   };
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -136,9 +136,11 @@ expect.extend({
       return {
         pass: false,
         message: () =>
-          'Expected valid template, got:' +
+          'Expected valid template, got error(s):' +
           '\n' +
-          result.errors.map((e) => e.message).join('\n'),
+          result.errors
+            .map((e) => `- ${e.path.join('.')} ${e.message}`)
+            .join('\n'),
       };
     }
 


### PR DESCRIPTION
[Sample Templates in the CFN docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-sample-templates.html#w2ab1c31c28c21c31b5) are using strings for Paramters.