### PR TITLE
feat: support outputs in template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ jspm_packages/
 .yarn-integrity
 .cache
 cdk.out
+/.idea
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -57,7 +57,7 @@ const project = new typescript.TypeScriptProject({
     },
   },
 
-  gitignore: ['cdk.out'],
+  gitignore: ['cdk.out', '/.idea'],
 });
 
 // Build schema after compilation

--- a/examples/apigw.json
+++ b/examples/apigw.json
@@ -32,5 +32,14 @@
         "httpMethod": "GET"
       }
     }
+  },
+  "Outputs": {
+    "SimpleValue": {
+      "Value": "SimpleValue",
+      "Description": "Sample primitive output value",
+      "Export": {
+        "Name": "SimpleValueExportName"
+      }
+    }
   }
 }

--- a/examples/lambda-topic.json
+++ b/examples/lambda-topic.json
@@ -21,5 +21,17 @@
         ]
       }
     }
+  },
+  "Outputs": {
+    "FunctionArn": {
+      "Value": {
+        "CDK::GetProp": "Lambda.functionName"
+      },
+      "Export": {
+        "Name": {
+          "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "FunctionName"]]
+        }
+      }
+    }
   }
 }

--- a/examples/pure-cfn.json
+++ b/examples/pure-cfn.json
@@ -14,5 +14,19 @@
         "LogGroupName": { "Ref": "AWS::AccountId" }
       }
     }
+  },
+  "Outputs": {
+    "LogGroupArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "MyLogGroup",
+          "Arn"
+        ]
+      },
+      "Export": {
+        "Name": "MyLogGroupArn"
+      },
+      "Description": "Return log group arn"
+    }
   }
 }

--- a/src/evaluate/outputs.ts
+++ b/src/evaluate/outputs.ts
@@ -1,0 +1,41 @@
+import { CfnElement } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface DeCdkCfnOutputProps {
+  value: any;
+  description?: string;
+  exportName?: any;
+  condition?: string;
+}
+
+export class DeCDKCfnOutput extends CfnElement {
+  private readonly value: any;
+  private readonly description?: string;
+  private readonly exportName?: any;
+  private readonly condition?: string;
+  constructor(scope: Construct, id: string, props: DeCdkCfnOutputProps) {
+    super(scope, id);
+    if (props.value === undefined) {
+      throw new Error(
+        `Missing value for CloudFormation output at path "${this.node.path}"`
+      );
+    }
+    this.value = props.value;
+    this.condition = props.condition;
+    this.description = props.description;
+    this.exportName = props.exportName;
+  }
+
+  public _toCloudFormation(): object {
+    return {
+      Outputs: {
+        [this.logicalId]: {
+          Description: this.description,
+          Value: this.value,
+          Export: this.exportName ? { Name: this.exportName } : undefined,
+          Condition: this.condition ?? undefined,
+        },
+      },
+    };
+  }
+}

--- a/src/parser/template/index.ts
+++ b/src/parser/template/index.ts
@@ -3,3 +3,4 @@ export * from './expression';
 export * from './parameters';
 export * from './resource';
 export * from './template';
+export * from './output';

--- a/src/type-resolution/expression.ts
+++ b/src/type-resolution/expression.ts
@@ -63,3 +63,52 @@ export function assertExpressionShaped(x: unknown): TypedTemplateExpression {
 
   return x as TypedTemplateExpression;
 }
+
+export interface TypedTemplateOutput {
+  readonly description?: string;
+  readonly value: TypedTemplateExpression;
+  readonly exportName?: TypedTemplateExpression;
+  readonly conditionName?: string;
+}
+
+export function toTypedTemplateExpression(
+  input: TemplateExpression
+): TypedTemplateExpression {
+  switch (input.type) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return {
+        type: input.type,
+        value: input.value,
+      } as TypedTemplateExpression;
+    case 'array':
+      return {
+        type: 'array',
+        array: convertArray(input.array),
+      } as TypedArrayExpression;
+    case 'object':
+      return {
+        type: 'object',
+        fields: convertObject(input.fields),
+      } as TypedObjectExpression;
+    case 'intrinsic':
+      return input;
+    default:
+      throw new Error(`Encounter unexpected type ${input}`);
+  }
+}
+
+export function convertArray(
+  xs: TemplateExpression[]
+): TypedTemplateExpression[] {
+  return xs.map((item) => toTypedTemplateExpression(item));
+}
+
+export function convertObject(
+  xs: Record<string, TemplateExpression>
+): Record<string, TypedTemplateExpression> {
+  return Object.fromEntries(
+    Object.entries(xs).map(([k, v]) => [k, toTypedTemplateExpression(v)])
+  );
+}

--- a/src/type-resolution/template.ts
+++ b/src/type-resolution/template.ts
@@ -6,7 +6,7 @@ import {
   TemplateParameter,
 } from '../parser/template';
 import { TemplateMapping } from '../parser/template/mappings';
-import { TemplateOutput } from '../parser/template/output';
+import { toTypedTemplateExpression, TypedTemplateOutput } from './expression';
 import { resolveResourceLike, ResourceLike } from './resource-like';
 
 export interface TypedTemplateProps {
@@ -21,7 +21,7 @@ export class TypedTemplate {
   public readonly parameters: Map<string, TemplateParameter>;
   public readonly conditions: Map<string, TemplateExpression>;
   public readonly mappings: Map<string, TemplateMapping>;
-  public readonly outputs: Map<string, TemplateOutput>;
+  public readonly outputs: Map<string, TypedTemplateOutput>;
 
   constructor(public template: Template, props: TypedTemplateProps) {
     this.resources = template
@@ -33,7 +33,18 @@ export class TypedTemplate {
     this.parameters = template.parameters;
     this.conditions = template.conditions;
     this.mappings = template.mappings;
-    this.outputs = template.outputs;
+    this.outputs = new Map();
+    for (let [logicalId, output] of template.outputs) {
+      const typedOutput = {
+        exportName: output.exportName
+          ? toTypedTemplateExpression(output.exportName)
+          : output.exportName,
+        conditionName: output.conditionName,
+        value: toTypedTemplateExpression(output.value),
+        description: output.description,
+      } as TypedTemplateOutput;
+      this.outputs.set(logicalId, typedOutput);
+    }
   }
 
   public resource(logicalId: string) {

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -31,6 +31,13 @@ Object {
         ],
       },
     },
+    "SimpleValue": Object {
+      "Description": "Sample primitive output value",
+      "Export": Object {
+        "Name": "SimpleValueExportName",
+      },
+      "Value": "SimpleValue",
+    },
   },
   "Resources": Object {
     "GetRootA9424890": Object {
@@ -3313,6 +3320,26 @@ Object {
 
 exports[`lambda-topic.json 1`] = `
 Object {
+  "Outputs": Object {
+    "FunctionArn": Object {
+      "Export": Object {
+        "Name": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "FunctionName",
+            ],
+          ],
+        },
+      },
+      "Value": Object {
+        "Ref": "LambdaD247545B",
+      },
+    },
+  },
   "Resources": Object {
     "LambdaAllowInvokeTestTopic346FF53781B07C89": Object {
       "Properties": Object {
@@ -4795,6 +4822,20 @@ Object {
 exports[`pure-cfn.json 1`] = `
 Object {
   "AWSTemplateFormatVersion": "2010-09-09",
+  "Outputs": Object {
+    "LogGroupArn": Object {
+      "Description": "Return log group arn",
+      "Export": Object {
+        "Name": "MyLogGroupArn",
+      },
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "MyLogGroup",
+          "Arn",
+        ],
+      },
+    },
+  },
   "Resources": Object {
     "Hello4A628BD4": Object {
       "DeletionPolicy": "Delete",

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -265,3 +265,152 @@ describe('given a template with unknown top-level properties', () => {
     expect(template.toJSON()).not.toHaveProperty('Whatever');
   });
 });
+
+describe('Outputs', () => {
+  test('Simple value output', async () => {
+    const template = await Testing.template(
+      await Template.fromObject({
+        Resources: {
+          handler: {
+            Type: 'AWS::CloudFormation::WaitConditionHandler',
+          },
+        },
+        Outputs: {
+          SimpleOutput: {
+            Value: 'StringValue',
+            Description: 'Description',
+            Export: {
+              Name: 'ExportName',
+            },
+          },
+        },
+      }),
+      false
+    );
+
+    template.hasOutput('SimpleOutput', {
+      Description: 'Description',
+      Value: 'StringValue',
+      Export: {
+        Name: 'ExportName',
+      },
+    });
+    expect(template.toJSON()).toHaveProperty('Outputs');
+  });
+
+  test('Simple output with condition', async () => {
+    const template = await Testing.template(
+      await Template.fromObject({
+        Parameters: {
+          Stage: {
+            Type: 'String',
+            Default: 'Prod',
+          },
+        },
+        Conditions: {
+          IsProd: {
+            'Fn::Equals': [
+              {
+                Ref: 'Stage',
+              },
+              'Prod',
+            ],
+          },
+        },
+        Resources: {
+          handler: {
+            Type: 'AWS::CloudFormation::WaitConditionHandler',
+          },
+        },
+        Outputs: {
+          SimpleOutput: {
+            Condition: 'IsProd',
+            Value: 'StringValue',
+            Description: 'Description',
+          },
+        },
+      }),
+      false
+    );
+
+    template.hasOutput('SimpleOutput', {
+      Condition: 'IsProd',
+      Description: 'Description',
+      Value: 'StringValue',
+    });
+    template.hasParameter('Stage', {
+      Type: 'String',
+      Default: 'Prod',
+    });
+    expect(template.toJSON()).toHaveProperty('Outputs');
+    expect(template.toJSON()).toHaveProperty('Parameters');
+  });
+
+  test('Simple output value with Fn::Join', async () => {
+    const template = await Testing.template(
+      await Template.fromObject({
+        Resources: {
+          handler: {
+            Type: 'AWS::CloudFormation::WaitConditionHandler',
+          },
+        },
+        Outputs: {
+          SimpleOutput: {
+            Value: {
+              'Fn::Join': ['-', ['simple', 'output', 'value']],
+            },
+            Description: 'Description',
+            Export: {
+              Name: 'ExportName',
+            },
+          },
+        },
+      }),
+      false
+    );
+
+    template.hasOutput('SimpleOutput', {
+      Description: 'Description',
+      Value: 'simple-output-value',
+      Export: {
+        Name: 'ExportName',
+      },
+    });
+    expect(template.toJSON()).toHaveProperty('Outputs');
+  });
+
+  test('Simple export value with Fn::Join', async () => {
+    const template = await Testing.template(
+      await Template.fromObject({
+        Resources: {
+          handler: {
+            Type: 'AWS::CloudFormation::WaitConditionHandler',
+          },
+        },
+        Outputs: {
+          SimpleOutput: {
+            Value: {
+              'Fn::Join': ['-', ['simple', 'output', 'value']],
+            },
+            Description: 'Description',
+            Export: {
+              Name: {
+                'Fn::Join': ['-', ['export', 'value']],
+              },
+            },
+          },
+        },
+      }),
+      false
+    );
+
+    template.hasOutput('SimpleOutput', {
+      Description: 'Description',
+      Value: 'simple-output-value',
+      Export: {
+        Name: 'export-value',
+      },
+    });
+    expect(template.toJSON()).toHaveProperty('Outputs');
+  });
+});

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -4,7 +4,20 @@ exports[`apigw.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
   "mappings": Map {},
-  "outputs": Map {},
+  "outputs": Map {
+    "SimpleValue" => Object {
+      "conditionName": undefined,
+      "description": "Sample primitive output value",
+      "exportName": Object {
+        "type": "string",
+        "value": "SimpleValueExportName",
+      },
+      "value": Object {
+        "type": "string",
+        "value": "SimpleValue",
+      },
+    },
+  },
   "parameters": Map {},
   "resources": DependencyGraph {
     "_dependencies": Map {
@@ -124,7 +137,20 @@ TypedTemplate {
     "conditions": Map {},
     "description": "A template creates a lambda function with an api gateway",
     "mappings": Map {},
-    "outputs": Map {},
+    "outputs": Map {
+      "SimpleValue" => Object {
+        "conditionName": undefined,
+        "description": "Sample primitive output value",
+        "exportName": Object {
+          "type": "string",
+          "value": "SimpleValueExportName",
+        },
+        "value": Object {
+          "type": "string",
+          "value": "SimpleValue",
+        },
+      },
+    },
     "parameters": Map {},
     "resources": Map {
       "HelloLambda" => Object {
@@ -233,6 +259,15 @@ TypedTemplate {
       "$schema": "../cdk.schema.json",
       "AWSTemplateFormatVersion": "2010-09-09",
       "Description": "A template creates a lambda function with an api gateway",
+      "Outputs": Object {
+        "SimpleValue": Object {
+          "Description": "Sample primitive output value",
+          "Export": Object {
+            "Name": "SimpleValueExportName",
+          },
+          "Value": "SimpleValue",
+        },
+      },
       "Resources": Object {
         "GetRoot": Object {
           "Properties": Object {
@@ -4667,7 +4702,37 @@ exports[`lambda-topic.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
   "mappings": Map {},
-  "outputs": Map {},
+  "outputs": Map {
+    "FunctionArn" => Object {
+      "conditionName": undefined,
+      "description": undefined,
+      "exportName": Object {
+        "fn": "join",
+        "list": Object {
+          "array": Array [
+            Object {
+              "fn": "ref",
+              "logicalId": "AWS::StackName",
+              "type": "intrinsic",
+            },
+            Object {
+              "type": "string",
+              "value": "FunctionName",
+            },
+          ],
+          "type": "array",
+        },
+        "separator": "-",
+        "type": "intrinsic",
+      },
+      "value": Object {
+        "fn": "getProp",
+        "logicalId": "Lambda",
+        "property": "functionName",
+        "type": "intrinsic",
+      },
+    },
+  },
   "parameters": Map {},
   "resources": DependencyGraph {
     "_dependencies": Map {
@@ -4768,7 +4833,37 @@ TypedTemplate {
     "conditions": Map {},
     "description": undefined,
     "mappings": Map {},
-    "outputs": Map {},
+    "outputs": Map {
+      "FunctionArn" => Object {
+        "conditionName": undefined,
+        "description": undefined,
+        "exportName": Object {
+          "fn": "join",
+          "list": Object {
+            "array": Array [
+              Object {
+                "fn": "ref",
+                "logicalId": "AWS::StackName",
+                "type": "intrinsic",
+              },
+              Object {
+                "type": "string",
+                "value": "FunctionName",
+              },
+            ],
+            "type": "array",
+          },
+          "separator": "-",
+          "type": "intrinsic",
+        },
+        "value": Object {
+          "fn": "getProp",
+          "logicalId": "Lambda",
+          "property": "functionName",
+          "type": "intrinsic",
+        },
+      },
+    },
     "parameters": Map {},
     "resources": Map {
       "Topic" => Object {
@@ -4847,6 +4942,26 @@ TypedTemplate {
     },
     "template": Object {
       "$schema": "../cdk.schema.json",
+      "Outputs": Object {
+        "FunctionArn": Object {
+          "Export": Object {
+            "Name": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                  "FunctionName",
+                ],
+              ],
+            },
+          },
+          "Value": Object {
+            "CDK::GetProp": "Lambda.functionName",
+          },
+        },
+      },
       "Resources": Object {
         "Lambda": Object {
           "Properties": Object {
@@ -6215,7 +6330,25 @@ exports[`pure-cfn.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
   "mappings": Map {},
-  "outputs": Map {},
+  "outputs": Map {
+    "LogGroupArn" => Object {
+      "conditionName": undefined,
+      "description": "Return log group arn",
+      "exportName": Object {
+        "type": "string",
+        "value": "MyLogGroupArn",
+      },
+      "value": Object {
+        "attribute": Object {
+          "type": "string",
+          "value": "Arn",
+        },
+        "fn": "getAtt",
+        "logicalId": "MyLogGroup",
+        "type": "intrinsic",
+      },
+    },
+  },
   "parameters": Map {},
   "resources": DependencyGraph {
     "_dependencies": Map {
@@ -6288,7 +6421,25 @@ TypedTemplate {
     "conditions": Map {},
     "description": undefined,
     "mappings": Map {},
-    "outputs": Map {},
+    "outputs": Map {
+      "LogGroupArn" => Object {
+        "conditionName": undefined,
+        "description": "Return log group arn",
+        "exportName": Object {
+          "type": "string",
+          "value": "MyLogGroupArn",
+        },
+        "value": Object {
+          "attribute": Object {
+            "type": "string",
+            "value": "Arn",
+          },
+          "fn": "getAtt",
+          "logicalId": "MyLogGroup",
+          "type": "intrinsic",
+        },
+      },
+    },
     "parameters": Map {},
     "resources": Map {
       "Hello" => Object {
@@ -6346,6 +6497,20 @@ TypedTemplate {
     "template": Object {
       "$schema": "../cdk.schema.json",
       "AWSTemplateFormatVersion": "2010-09-09",
+      "Outputs": Object {
+        "LogGroupArn": Object {
+          "Description": "Return log group arn",
+          "Export": Object {
+            "Name": "MyLogGroupArn",
+          },
+          "Value": Object {
+            "Fn::GetAtt": Array [
+              "MyLogGroup",
+              "Arn",
+            ],
+          },
+        },
+      },
       "Resources": Object {
         "Hello": Object {
           "Properties": Object {


### PR DESCRIPTION
Fixes https://github.com/cdklabs/decdk/issues/249

Note:

A new construct of CfnOutput is created because:
1. In cdk lib, `output.value` is set to a string in [OutputProp](https://github.com/aws/aws-cdk/blob/cea1039e3664fdfa89c6f00cdaeb1a0185a12678/packages/%40aws-cdk/core/lib/cfn-output.ts#L18).
2. Type of `Condition` is `CfnCondition` while in decdk, we can treat it as a string.