### PR TITLE
feat: allow null to indicate an empty args list

### DIFF
--- a/examples/application-load-balancer.yaml
+++ b/examples/application-load-balancer.yaml
@@ -12,7 +12,7 @@ Resources:
           - T2
           - MICRO
       machineImage:
-        aws-cdk-lib.aws_ec2.AmazonLinuxImage: []
+        aws-cdk-lib.aws_ec2.AmazonLinuxImage: # parameters may be omitted when there are no mandatory arguments
   AModestLoad:
     Type: aws-cdk-lib.aws_autoscaling.TargetTrackingScalingPolicy
     'On': ASG

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -83,6 +83,8 @@ export class Evaluator {
       y ? ev(y) : undefined;
 
     switch (x.type) {
+      case 'null':
+        return undefined;
       case 'string':
       case 'number':
       case 'boolean':

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -13,6 +13,7 @@ export type TemplateExpression =
   | ArrayLiteral
   | NumberLiteral
   | BooleanLiteral
+  | NullLiteral
   | IntrinsicExpression;
 
 export interface StringLiteral {
@@ -28,6 +29,10 @@ export interface NumberLiteral {
 export interface BooleanLiteral {
   readonly type: 'boolean';
   readonly value: boolean;
+}
+
+export interface NullLiteral {
+  readonly type: 'null';
 }
 
 export interface ObjectExpression<T> {
@@ -231,6 +236,9 @@ export function assertExpression(x: unknown): TemplateExpression {
 }
 
 export function parseExpression(x: unknown): TemplateExpression {
+  if (x == null) {
+    return { type: 'null' };
+  }
   if (typeof x === 'string') {
     return { type: 'string', value: x };
   }

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -498,14 +498,25 @@ function methodSchema(method: jsiiReflect.Callable, ctx: SchemaContext) {
       addProperty(p);
     }
 
-    const basicSchema = {
-      type: 'array',
-      items: properties.map((p) => ({
-        anyOf: [p, $ref('IntrinsicExpression')],
-      })),
-    };
+    const basicSchema =
+      required.length > 0
+        ? {
+            type: 'array',
+            items: properties.map((p) => ({
+              anyOf: [p, $ref('IntrinsicExpression')],
+            })),
+            maxItems: properties.length,
+          }
+        : {
+            type: ['array', 'null'],
+            maxItems: 0,
+          };
 
-    if (properties.length > 0 && required.length < 2) {
+    if (
+      basicSchema.items &&
+      basicSchema.items.length > 0 &&
+      required.length < 2
+    ) {
       return {
         anyOf: [basicSchema, basicSchema.items[0]],
       };

--- a/src/type-resolution/callables.ts
+++ b/src/type-resolution/callables.ts
@@ -283,7 +283,9 @@ export function resolvePositionalCallableParameters(
   x: ArrayLiteral,
   callable: reflect.Callable
 ): TypedArrayExpression {
-  const paramArray = prepareParameters(x, callable);
+  const paramArray = prepareParameters(x, callable).filter(
+    (expr) => expr.type !== 'null'
+  );
   const args: TypedTemplateExpression[] = [];
 
   for (let i = 0; i < callable.parameters.length; i++) {

--- a/src/type-resolution/expression.ts
+++ b/src/type-resolution/expression.ts
@@ -3,6 +3,7 @@ import {
   ArrayExpression,
   BooleanLiteral,
   IntrinsicExpression,
+  NullLiteral,
   NumberLiteral,
   ObjectExpression,
   StringLiteral,
@@ -23,6 +24,7 @@ export type TypedTemplateExpression =
   | NumberLiteral
   | BooleanLiteral
   | DateLiteral
+  | NullLiteral
   | TypedArrayExpression
   | TypedObjectExpression
   | EnumExpression

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -597,8 +597,7 @@ TypedTemplate {
           "machineImage": Object {
             "fields": Object {
               "aws-cdk-lib.aws_ec2.AmazonLinuxImage": Object {
-                "array": Array [],
-                "type": "array",
+                "type": "null",
               },
             },
             "type": "object",
@@ -826,7 +825,7 @@ TypedTemplate {
               ],
             },
             "machineImage": Object {
-              "aws-cdk-lib.aws_ec2.AmazonLinuxImage": Array [],
+              "aws-cdk-lib.aws_ec2.AmazonLinuxImage": null,
             },
             "vpc": Object {
               "Ref": "VPC",


### PR DESCRIPTION
Creates a new type in the AST, `null`, which will be interpreted as an empty list in case of method and constructor parameters.