### PR TITLE
fix: allow class implementations when expected type is a class, not only when it's an interface

### DIFF
--- a/examples/http-proxy.yaml
+++ b/examples/http-proxy.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../cdk.schema.json
+Parameters:
+  ProxyUrl:
+    Type: String
+    Default: https://aws.amazon.com/ko/
+Resources:
+  ProxyApi:
+    Type: aws-cdk-lib.aws_apigateway.RestApi
+    Properties:
+      restApiName: Hello
+      endpointConfiguration:
+        types:
+          - EDGE
+  ProxyResource:
+    Type: aws-cdk-lib.aws_apigateway.ProxyResource
+    Properties:
+      parent:
+        CDK::GetProp: ProxyApi.root
+      anyMethod: false
+  ProxyMethod:
+    Type: aws-cdk-lib.aws_apigateway.Method
+    Properties:
+      httpMethod: GET
+      resource:
+        Ref: ProxyResource
+      integration:
+        aws-cdk-lib.aws_apigateway.HttpIntegration:
+          - Fn::Join: ['/', [!Ref ProxyUrl, '{proxy}']]
+          - proxy: true
+            httpMethod: GET
+            options:
+              requestParameters:
+                integration.request.path.proxy: method.request.path.proxy
+      options:
+        requestParameters:
+          method.request.path.proxy: true

--- a/src/type-resolution/resolve.ts
+++ b/src/type-resolution/resolve.ts
@@ -89,6 +89,13 @@ export function resolveExpressionType(
           assertInterface(typeRef)
         )
       );
+    case ResolvableExpressionType.OTHER_CLASS:
+      return refOrResolve(x, (y) =>
+        resolveInstanceExpression(
+          assertExpressionType(y, 'object'),
+          assertClass(typeRef)
+        )
+      );
 
     case ResolvableExpressionType.CONSTRUCT:
       return resolveRefToValue(assertRef(x));
@@ -121,6 +128,7 @@ export enum ResolvableExpressionType {
   STRUCT,
   BEHAVIORAL_INTERFACE,
   CONSTRUCT,
+  OTHER_CLASS,
 }
 
 export function analyzeTypeReference(
@@ -172,7 +180,7 @@ export function analyzeTypeReference(
     return ResolvableExpressionType.CONSTRUCT;
   }
   if (typeRef.type?.isClassType()) {
-    return ResolvableExpressionType.BEHAVIORAL_INTERFACE;
+    return ResolvableExpressionType.OTHER_CLASS;
   }
 
   return ResolvableExpressionType.UNKNOWN;

--- a/test/evaluate/__snapshots__/synth.test.ts.snap
+++ b/test/evaluate/__snapshots__/synth.test.ts.snap
@@ -3037,6 +3037,184 @@ Object {
 }
 `;
 
+exports[`http-proxy.yaml 1`] = `
+Object {
+  "Outputs": Object {
+    "ProxyApiEndpoint2177970D": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "ProxyApi0DF2D7AE",
+            },
+            ".execute-api.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "ProxyApiDeploymentStageprod9EF20FCC",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "ProxyUrl": Object {
+      "Default": "https://aws.amazon.com/ko/",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "ProxyApi0DF2D7AE": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "EDGE",
+          ],
+        },
+        "Name": "Hello",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "ProxyApiAccount987F032E": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "ProxyApi0DF2D7AE",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ProxyApiCloudWatchRole6287CBD0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ProxyApiCloudWatchRole6287CBD0": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ProxyApiDeployment6107D4F3d1a71147efeff25ca021f34ec61cf677": Object {
+      "DependsOn": Array [
+        "ProxyMethod54C3A837",
+        "ProxyResourceD65343FB",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "ProxyApi0DF2D7AE",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "ProxyApiDeploymentStageprod9EF20FCC": Object {
+      "DependsOn": Array [
+        "ProxyApiAccount987F032E",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "ProxyApiDeployment6107D4F3d1a71147efeff25ca021f34ec61cf677",
+        },
+        "RestApiId": Object {
+          "Ref": "ProxyApi0DF2D7AE",
+        },
+        "StageName": "prod",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "ProxyMethod54C3A837": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": Object {
+          "IntegrationHttpMethod": "GET",
+          "RequestParameters": Object {
+            "integration.request.path.proxy": "method.request.path.proxy",
+          },
+          "Type": "HTTP_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "/",
+              Array [
+                Object {
+                  "Ref": "ProxyUrl",
+                },
+                "{proxy}",
+              ],
+            ],
+          },
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "ProxyResourceD65343FB",
+        },
+        "RestApiId": Object {
+          "Ref": "ProxyApi0DF2D7AE",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "ProxyResourceD65343FB": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "ProxyApi0DF2D7AE",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "ProxyApi0DF2D7AE",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;
+
 exports[`lambda-dashboard.yaml 1`] = `
 Object {
   "Parameters": Object {

--- a/test/type-resolution/__snapshots__/examples.test.ts.snap
+++ b/test/type-resolution/__snapshots__/examples.test.ts.snap
@@ -6026,6 +6026,474 @@ TypedTemplate {
 }
 `;
 
+exports[`http-proxy.yaml 1`] = `
+TypedTemplate {
+  "conditions": Map {},
+  "mappings": Map {},
+  "metadata": Map {},
+  "outputs": Map {},
+  "parameters": Map {
+    "ProxyUrl" => Object {
+      "allowedPattern": undefined,
+      "allowedValues": undefined,
+      "constraintDescription": undefined,
+      "default": "https://aws.amazon.com/ko/",
+      "description": undefined,
+      "maxLength": undefined,
+      "maxValue": undefined,
+      "minLength": undefined,
+      "minValue": undefined,
+      "noEcho": undefined,
+      "type": "String",
+    },
+  },
+  "resources": DependencyGraph {
+    "_dependencies": Map {
+      "ProxyApi" => Set {},
+      "ProxyResource" => Set {
+        "ProxyApi",
+      },
+      "ProxyMethod" => Set {
+        "ProxyResource",
+      },
+    },
+    "keys": Set {
+      "ProxyApi",
+      "ProxyResource",
+      "ProxyMethod",
+    },
+    "nodes": Object {
+      "ProxyApi": Object {
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_apigateway.RestApi",
+        "logicalId": "ProxyApi",
+        "namespace": "aws_apigateway",
+        "overrides": Array [],
+        "props": Object {
+          "fields": Object {
+            "endpointConfiguration": Object {
+              "fields": Object {
+                "types": Object {
+                  "array": Array [
+                    Object {
+                      "choice": "EDGE",
+                      "fqn": "aws-cdk-lib.aws_apigateway.EndpointType",
+                      "namespace": "aws_apigateway",
+                      "type": "enum",
+                    },
+                  ],
+                  "type": "array",
+                },
+              },
+              "type": "struct",
+            },
+            "restApiName": Object {
+              "type": "string",
+              "value": "Hello",
+            },
+          },
+          "type": "struct",
+        },
+        "tags": Array [],
+        "type": "construct",
+      },
+      "ProxyMethod": Object {
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_apigateway.Method",
+        "logicalId": "ProxyMethod",
+        "namespace": "aws_apigateway",
+        "overrides": Array [],
+        "props": Object {
+          "fields": Object {
+            "httpMethod": Object {
+              "type": "string",
+              "value": "GET",
+            },
+            "integration": Object {
+              "args": Object {
+                "array": Array [
+                  Object {
+                    "fn": "join",
+                    "list": Object {
+                      "array": Array [
+                        Object {
+                          "fn": "ref",
+                          "logicalId": "ProxyUrl",
+                          "type": "intrinsic",
+                        },
+                        Object {
+                          "type": "string",
+                          "value": "{proxy}",
+                        },
+                      ],
+                      "type": "array",
+                    },
+                    "separator": "/",
+                    "type": "intrinsic",
+                  },
+                  Object {
+                    "fields": Object {
+                      "httpMethod": Object {
+                        "type": "string",
+                        "value": "GET",
+                      },
+                      "options": Object {
+                        "fields": Object {
+                          "requestParameters": Object {
+                            "fields": Object {
+                              "integration.request.path.proxy": Object {
+                                "type": "string",
+                                "value": "method.request.path.proxy",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        },
+                        "type": "struct",
+                      },
+                      "proxy": Object {
+                        "type": "boolean",
+                        "value": true,
+                      },
+                    },
+                    "type": "struct",
+                  },
+                ],
+                "type": "array",
+              },
+              "fqn": "aws-cdk-lib.aws_apigateway.HttpIntegration",
+              "namespace": "aws_apigateway",
+              "type": "initializer",
+            },
+            "options": Object {
+              "fields": Object {
+                "requestParameters": Object {
+                  "fields": Object {
+                    "method.request.path.proxy": Object {
+                      "type": "boolean",
+                      "value": true,
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+              "type": "struct",
+            },
+            "resource": Object {
+              "reference": Object {
+                "fn": "ref",
+                "logicalId": "ProxyResource",
+                "type": "intrinsic",
+              },
+              "type": "resolve-reference",
+            },
+          },
+          "type": "struct",
+        },
+        "tags": Array [],
+        "type": "construct",
+      },
+      "ProxyResource": Object {
+        "dependsOn": Array [],
+        "fqn": "aws-cdk-lib.aws_apigateway.ProxyResource",
+        "logicalId": "ProxyResource",
+        "namespace": "aws_apigateway",
+        "overrides": Array [],
+        "props": Object {
+          "fields": Object {
+            "anyMethod": Object {
+              "type": "boolean",
+              "value": false,
+            },
+            "parent": Object {
+              "reference": Object {
+                "fn": "getProp",
+                "logicalId": "ProxyApi",
+                "property": "root",
+                "type": "intrinsic",
+              },
+              "type": "resolve-reference",
+            },
+          },
+          "type": "struct",
+        },
+        "tags": Array [],
+        "type": "construct",
+      },
+    },
+  },
+  "rules": Map {},
+  "template": Template {
+    "conditions": Map {},
+    "description": undefined,
+    "mappings": Map {},
+    "metadata": Map {},
+    "outputs": Map {},
+    "parameters": Map {
+      "ProxyUrl" => Object {
+        "allowedPattern": undefined,
+        "allowedValues": undefined,
+        "constraintDescription": undefined,
+        "default": "https://aws.amazon.com/ko/",
+        "description": undefined,
+        "maxLength": undefined,
+        "maxValue": undefined,
+        "minLength": undefined,
+        "minValue": undefined,
+        "noEcho": undefined,
+        "type": "String",
+      },
+    },
+    "resources": Map {
+      "ProxyApi" => Object {
+        "call": Object {
+          "fields": Object {},
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "creationPolicy": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {},
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {
+          "endpointConfiguration": Object {
+            "fields": Object {
+              "types": Object {
+                "array": Array [
+                  Object {
+                    "type": "string",
+                    "value": "EDGE",
+                  },
+                ],
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "restApiName": Object {
+            "type": "string",
+            "value": "Hello",
+          },
+        },
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_apigateway.RestApi",
+        "updatePolicy": undefined,
+        "updateReplacePolicy": "Delete",
+      },
+      "ProxyResource" => Object {
+        "call": Object {
+          "fields": Object {},
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "creationPolicy": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "ProxyApi",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {
+          "anyMethod": Object {
+            "type": "boolean",
+            "value": false,
+          },
+          "parent": Object {
+            "fn": "getProp",
+            "logicalId": "ProxyApi",
+            "property": "root",
+            "type": "intrinsic",
+          },
+        },
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_apigateway.ProxyResource",
+        "updatePolicy": undefined,
+        "updateReplacePolicy": "Delete",
+      },
+      "ProxyMethod" => Object {
+        "call": Object {
+          "fields": Object {},
+          "type": "object",
+        },
+        "conditionName": undefined,
+        "creationPolicy": undefined,
+        "deletionPolicy": "Delete",
+        "dependencies": Set {
+          "ProxyResource",
+          "ProxyUrl",
+        },
+        "dependsOn": Set {},
+        "metadata": Object {},
+        "on": undefined,
+        "overrides": Array [],
+        "properties": Object {
+          "httpMethod": Object {
+            "type": "string",
+            "value": "GET",
+          },
+          "integration": Object {
+            "fields": Object {
+              "aws-cdk-lib.aws_apigateway.HttpIntegration": Object {
+                "array": Array [
+                  Object {
+                    "fn": "join",
+                    "list": Object {
+                      "array": Array [
+                        Object {
+                          "fn": "ref",
+                          "logicalId": "ProxyUrl",
+                          "type": "intrinsic",
+                        },
+                        Object {
+                          "type": "string",
+                          "value": "{proxy}",
+                        },
+                      ],
+                      "type": "array",
+                    },
+                    "separator": "/",
+                    "type": "intrinsic",
+                  },
+                  Object {
+                    "fields": Object {
+                      "httpMethod": Object {
+                        "type": "string",
+                        "value": "GET",
+                      },
+                      "options": Object {
+                        "fields": Object {
+                          "requestParameters": Object {
+                            "fields": Object {
+                              "integration.request.path.proxy": Object {
+                                "type": "string",
+                                "value": "method.request.path.proxy",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "proxy": Object {
+                        "type": "boolean",
+                        "value": true,
+                      },
+                    },
+                    "type": "object",
+                  },
+                ],
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "options": Object {
+            "fields": Object {
+              "requestParameters": Object {
+                "fields": Object {
+                  "method.request.path.proxy": Object {
+                    "type": "boolean",
+                    "value": true,
+                  },
+                },
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "resource": Object {
+            "fn": "ref",
+            "logicalId": "ProxyResource",
+            "type": "intrinsic",
+          },
+        },
+        "tags": Array [],
+        "type": "aws-cdk-lib.aws_apigateway.Method",
+        "updatePolicy": undefined,
+        "updateReplacePolicy": "Delete",
+      },
+    },
+    "rules": Map {},
+    "template": Object {
+      "Parameters": Object {
+        "ProxyUrl": Object {
+          "Default": "https://aws.amazon.com/ko/",
+          "Type": "String",
+        },
+      },
+      "Resources": Object {
+        "ProxyApi": Object {
+          "Properties": Object {
+            "endpointConfiguration": Object {
+              "types": Array [
+                "EDGE",
+              ],
+            },
+            "restApiName": "Hello",
+          },
+          "Type": "aws-cdk-lib.aws_apigateway.RestApi",
+        },
+        "ProxyMethod": Object {
+          "Properties": Object {
+            "httpMethod": "GET",
+            "integration": Object {
+              "aws-cdk-lib.aws_apigateway.HttpIntegration": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "/",
+                    Array [
+                      Object {
+                        "Ref": "ProxyUrl",
+                      },
+                      "{proxy}",
+                    ],
+                  ],
+                },
+                Object {
+                  "httpMethod": "GET",
+                  "options": Object {
+                    "requestParameters": Object {
+                      "integration.request.path.proxy": "method.request.path.proxy",
+                    },
+                  },
+                  "proxy": true,
+                },
+              ],
+            },
+            "options": Object {
+              "requestParameters": Object {
+                "method.request.path.proxy": true,
+              },
+            },
+            "resource": Object {
+              "Ref": "ProxyResource",
+            },
+          },
+          "Type": "aws-cdk-lib.aws_apigateway.Method",
+        },
+        "ProxyResource": Object {
+          "Properties": Object {
+            "anyMethod": false,
+            "parent": Object {
+              "CDK::GetProp": "ProxyApi.root",
+            },
+          },
+          "Type": "aws-cdk-lib.aws_apigateway.ProxyResource",
+        },
+      },
+    },
+    "templateFormatVersion": undefined,
+    "transform": Array [],
+  },
+  "transform": Array [],
+}
+`;
+
 exports[`lambda-dashboard.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},

--- a/test/util.ts
+++ b/test/util.ts
@@ -190,7 +190,24 @@ export function matchConstruct(props: object) {
   });
 }
 
-export function matchInitializer(fqn: string, args: object[]) {
+export function matchLazyResource(call: any) {
+  return expect.objectContaining({
+    type: 'lazyResource',
+    call,
+  });
+}
+
+export function matchInstanceMethodCall(target: string, args: any[] = []) {
+  return expect.objectContaining({
+    type: 'instanceMethodCall',
+    logicalId: target,
+    args: {
+      type: 'array',
+      array: expect.arrayContaining(args),
+    },
+  });
+}
+export function matchInitializer(fqn: string, args: object[] = []) {
   return expect.objectContaining({
     type: 'initializer',
     fqn,


### PR DESCRIPTION
Conversion of
https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/http-proxy-apigateway and required fixes.

Note that I have adjusted the example to be more declarative and moved the edge-cases of a direct translation to unit tests.