### PR TITLE
feat: allow cyclic types in schema

### DIFF
--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -85,8 +85,7 @@ export class SchemaContext {
 
     if (!(fqn in this.definitions)) {
       if (this.definitionStack.includes(fqn)) {
-        this.error(`cyclic definition of ${fqn}`);
-        return undefined;
+        return $ref(fqn);
       }
 
       this.definitionStack.push(fqn);

--- a/src/type-resolution/resolve.ts
+++ b/src/type-resolution/resolve.ts
@@ -171,6 +171,9 @@ export function analyzeTypeReference(
   if (isConstruct(typeRef.type)) {
     return ResolvableExpressionType.CONSTRUCT;
   }
+  if (typeRef.type?.isClassType()) {
+    return ResolvableExpressionType.BEHAVIORAL_INTERFACE;
+  }
 
   return ResolvableExpressionType.UNKNOWN;
 }

--- a/src/type-system/interfaces.ts
+++ b/src/type-system/interfaces.ts
@@ -7,5 +7,9 @@ export function isBehavioralInterface(
     return false;
   }
 
-  return type.name.toLocaleUpperCase().startsWith('I');
+  return (
+    type.name.startsWith('I') &&
+    // Must check second char, otherwise names like `Integration` would match as well
+    type.name[1] === type.name[1].toLocaleUpperCase()
+  );
 }

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -445,13 +445,28 @@ describe('can evaluate cyclic types', () => {
               ],
             },
           },
+          MockIntegration: {
+            Type: 'aws-cdk-lib.aws_apigateway.MockIntegration',
+          },
+          MockMethod: {
+            Type: 'aws-cdk-lib.aws_apigateway.Method',
+            On: 'Api',
+            Call: {
+              'root.addMethod': [
+                'GET',
+                {
+                  Ref: 'MockIntegration',
+                },
+              ],
+            },
+          },
         },
       })
     );
 
     // THEN
-    template.hasResourceProperties('AWS::S3::Bucket', {
-      BucketName: { Ref: 'BucketName' },
-    });
+    template.resourceCountIs('AWS::ApiGateway::RestApi', 1);
+    template.resourceCountIs('AWS::ApiGateway::Model', 1);
+    template.resourceCountIs('AWS::ApiGateway::Method', 1);
   });
 });

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -414,3 +414,44 @@ describe('Outputs', () => {
     expect(template.toJSON()).toHaveProperty('Outputs');
   });
 });
+
+describe('can evaluate cyclic types', () => {
+  test('JsonSchema', async () => {
+    // GIVEN
+    const template = await Testing.template(
+      await Template.fromObject({
+        Resources: {
+          Api: {
+            Type: 'aws-cdk-lib.aws_apigateway.RestApi',
+          },
+          ResponseModel: {
+            On: 'Api',
+            Call: {
+              addModel: [
+                'ResponseModel',
+                {
+                  contentType: 'application/json',
+                  modelName: 'ResponseModel',
+                  schema: {
+                    schema: 'DRAFT4',
+                    title: 'pollResponse',
+                    type: 'OBJECT',
+                    properties: {
+                      state: { type: 'STRING' },
+                      greeting: { type: 'STRING' },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    // THEN
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: { Ref: 'BucketName' },
+    });
+  });
+});

--- a/test/type-system/interfaces.test.ts
+++ b/test/type-system/interfaces.test.ts
@@ -1,0 +1,20 @@
+import { isBehavioralInterface } from '../../src/type-system';
+import { Testing } from '../util';
+
+describe('isBehavioralInterface', () => {
+  test('IntegrationOptions', async () => {
+    const type = (await Testing.typeSystem).findFqn(
+      'aws-cdk-lib.aws_apigateway.IntegrationOptions'
+    );
+
+    expect(isBehavioralInterface(type)).toEqual(false);
+  });
+
+  test('ITopic', async () => {
+    const type = (await Testing.typeSystem).findFqn(
+      'aws-cdk-lib.aws_sns.ITopic'
+    );
+
+    expect(isBehavioralInterface(type)).toEqual(true);
+  });
+});


### PR DESCRIPTION
Enables cyclic references in JsonSchema. I did a check on the additional Schemas and there was no reason why these should not be included. Cyclic refs are allowed in JsonSchema. We can assume any cycle can be resolved correctly due to the data coming form CDK, i.e. all cyclic references will eventually end in an optional property thus breaking the loop in user land.

While adding an evaluation test, an issue emerged with classes starting with `I` being wrongly resolved as behavioral interface, as well as classes not being resolved if they didn't fit any of the other more narrow categories. This was tested and fixed as well.