### PR TITLE
fix: yaml not parsing certain values as string

### DIFF
--- a/src/parser/private/cfn-yaml.ts
+++ b/src/parser/private/cfn-yaml.ts
@@ -23,11 +23,27 @@ const shortForms: yaml_types.Schema.CustomTag[] = [
   .map((name) => intrinsicTag(name, true))
   .concat(intrinsicTag('Ref', false), intrinsicTag('Condition', false));
 
+const unsupportedTags = [
+  'tag:yaml.org,2002:binary',
+  'tag:yaml.org,2002:omap',
+  'tag:yaml.org,2002:pairs',
+  'tag:yaml.org,2002:set',
+  'tag:yaml.org,2002:timestamp',
+];
+
 export function parseCfnYaml(text: string): any {
   return yaml.parse(text, {
-    customTags: shortForms,
+    customTags: supportedTags,
+    version: '1.1',
     schema: 'yaml-1.1',
+    merge: false,
+    prettyErrors: true,
   });
+}
+
+function supportedTags(tags: yaml_types.Schema.Tag[]): yaml_types.Schema.Tag[] {
+  const filteredTags = tags.filter((t) => !unsupportedTags.includes(t.tag));
+  return filteredTags.concat(shortForms);
 }
 
 function intrinsicTag(

--- a/src/parser/private/cfn-yaml.ts
+++ b/src/parser/private/cfn-yaml.ts
@@ -41,9 +41,25 @@ export function parseCfnYaml(text: string): any {
   });
 }
 
+const unquotedDotTag: yaml_types.Schema.Tag = {
+  identify: (value: any) => typeof value === 'string',
+  default: true,
+  tag: 'tag:yaml.org,2002:str',
+  test: /^\.$/,
+  resolve: (str: string) => str,
+  stringify: () => '.',
+};
+
 function supportedTags(tags: yaml_types.Schema.Tag[]): yaml_types.Schema.Tag[] {
   const filteredTags = tags.filter((t) => !unsupportedTags.includes(t.tag));
-  return filteredTags.concat(shortForms);
+
+  const customTags: yaml_types.Schema.Tag[] = [];
+
+  customTags.push(unquotedDotTag);
+  customTags.push(...filteredTags);
+  customTags.push(...shortForms);
+
+  return customTags;
 }
 
 function intrinsicTag(

--- a/test/evaluate/__snapshots__/fixtures.test.ts.snap
+++ b/test/evaluate/__snapshots__/fixtures.test.ts.snap
@@ -616,6 +616,48 @@ Object {
 }
 `;
 
+exports[`Cloudformation templates cloudformation/json-in-fn-sub.yaml 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": Object {
+    "Stage": Object {
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "Dashboard": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{
+    \\"widgets\\": [
+        {
+            \\"type\\": \\"text\\",
+            \\"properties\\": {
+                \\"markdown\\": \\"\${Stage} \${Stage}\\"
+            }
+        },
+        {
+            \\"type\\": \\"text\\",
+            \\"properties\\": {
+                \\"markdown\\": \\"\${Stage} \${Stage}\\"
+            }
+        }
+    ]
+}
+",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${Stage}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
 exports[`Cloudformation templates cloudformation/long-form-subnet.yaml 1`] = `
 Object {
   "Conditions": Object {
@@ -1736,6 +1778,37 @@ yum update -y aws-cfn-bootstrap
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
+exports[`Cloudformation templates cloudformation/year-month-date-as-strings.yaml 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": Object {
+    "Role": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ec2.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Delete",
     },
   },

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -18,25 +18,23 @@ describe('Cloudformation templates', () => {
     path.join(__dirname, '..', 'fixtures/templates/cloudformation'),
   ]);
 
-  const ignoreBecauseCurrentlyFailing = [
-    'cloudformation/condition-same-name-as-resource.json',
-    'cloudformation/condition-using-mapping.json',
-    'cloudformation/find-in-map-for-boolean-property.json',
-    'cloudformation/find-in-map-with-dynamic-mapping.json',
-    'cloudformation/fn-sub-escaping.json',
-    'cloudformation/fn-sub-parsing-edges.json',
-    'cloudformation/fn-sub-shadow-attribute.json',
-    'cloudformation/functions-and-conditions.json',
-    'cloudformation/hook-code-deploy-blue-green-ecs.json',
-    'cloudformation/if-in-tags.json',
-    'cloudformation/json-in-fn-sub.yaml',
-    'cloudformation/only-parameters-and-rule.json',
-    'cloudformation/outputs-with-references.json',
-    'cloudformation/parameter-references.json',
-    'cloudformation/resource-attribute-creation-policy.json',
-    'cloudformation/resource-attribute-update-policy.json',
-    'cloudformation/short-form-fnsub-string.yaml',
-    'cloudformation/year-month-date-as-strings.yaml',
+  const ignoreBecauseCurrentlyFailing: string[] = [
+    'cloudformation/condition-same-name-as-resource.json', // There is already a Construct with name 'AlwaysTrue' in DeclarativeStack [Test]
+    'cloudformation/condition-using-mapping.json', // does not look like a template
+    'cloudformation/find-in-map-for-boolean-property.json', // Expected string or list of strings, got: true
+    'cloudformation/find-in-map-with-dynamic-mapping.json', // Expected string, got: {"Ref":"Stage"}
+    'cloudformation/fn-sub-escaping.json', //  No resource or parameter with name:  ! DoesNotExist
+    'cloudformation/fn-sub-parsing-edges.json', // TypeError: Cannot read properties of null (reading 'Resources')
+    'cloudformation/fn-sub-shadow-attribute.json', //  No resource or parameter with name: AnotherBucket
+    'cloudformation/functions-and-conditions.json', // Expected list of length 3, got 2
+    'cloudformation/hook-code-deploy-blue-green-ecs.json', // Expected valid template, got error(s): -  is not allowed to have the additional property "Hooks"
+    'cloudformation/if-in-tags.json', // Expected valid template, got error(s): - Conditions.ValcacheServerEnabled is not of a type(s) object
+    'cloudformation/only-parameters-and-rule.json', // does not look like a template
+    'cloudformation/outputs-with-references.json', // Expected string, got: {"Ref":"Bucket"}
+    'cloudformation/parameter-references.json', // Expected string or list of strings, got: {"Name":"AWS::Include","Parameters":{"Location":{"Ref":"MyParam"}}}
+    'cloudformation/resource-attribute-creation-policy.json', // Expected number, got: {"Ref":"CountParameter"}
+    'cloudformation/resource-attribute-update-policy.json', // Expected boolean, got: {"Fn::Equals":["true",{"Ref":"WaitOnResourceSignals"}]}
+    'cloudformation/short-form-fnsub-string.yaml', // No resource or parameter with name:  ! AWS::Region
   ];
 
   testTemplateFixtures(

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -5,10 +5,7 @@ import { testTemplateFixtures, Testing, loadTemplateFixtures } from '../util';
 describe('Valid Template Fixtures should synth', () => {
   testTemplateFixtures(async (templateFile) => {
     const template = await readTemplate(templateFile.path);
-
     const output = await Testing.synth(template);
-
-    expect(template.template).toBeValidTemplate();
     expect(output.template).toMatchSnapshot();
   });
 });
@@ -41,7 +38,6 @@ describe('Cloudformation templates', () => {
     async (templateFile) => {
       const template = await readTemplate(templateFile.path);
       const output = await Testing.synth(template);
-      expect(template.template).toBeValidTemplate();
       expect(output.template).toMatchSnapshot();
     },
     cfnFixtures.filter(({ id }) => !ignoreBecauseCurrentlyFailing.includes(id))
@@ -93,7 +89,6 @@ describe('SAM templates', () => {
   testTemplateFixtures(async (templateFile) => {
     const template = await readTemplate(templateFile.path);
     const output = await Testing.synth(template);
-    expect(template.template).toBeValidTemplate();
     expect(output.template).toMatchSnapshot();
   }, samFixtures);
 });
@@ -106,7 +101,6 @@ describe('Nested Stacks templates', () => {
   testTemplateFixtures(async (templateFile) => {
     const template = await readTemplate(templateFile.path);
     const output = await Testing.synth(template);
-    expect(template.template).toBeValidTemplate();
     expect(output.template).toMatchSnapshot();
   }, nestedFixtures);
 });

--- a/test/parser/yaml.test.ts
+++ b/test/parser/yaml.test.ts
@@ -16,6 +16,14 @@ test("Unquoted 'No' is treated as a boolean", () => {
   });
 });
 
+test("Unquoted '.' is treated as a string", () => {
+  const value = parseCfnYaml('Key: .');
+
+  expect(value).toEqual({
+    Key: '.',
+  });
+});
+
 test("Short-form 'Ref' is deserialized correctly", () => {
   const value = parseCfnYaml('!Ref Resource');
 

--- a/test/parser/yaml.test.ts
+++ b/test/parser/yaml.test.ts
@@ -1,0 +1,44 @@
+import { parseCfnYaml } from '../../src/parser/private/cfn-yaml';
+
+test('Unquoted year-month-day is treated as a string, not a Date', () => {
+  const value = parseCfnYaml('Key: 2020-12-31');
+
+  expect(value).toEqual({
+    Key: '2020-12-31',
+  });
+});
+
+test("Unquoted 'No' is treated as a boolean", () => {
+  const value = parseCfnYaml('Key: No');
+
+  expect(value).toEqual({
+    Key: false,
+  });
+});
+
+test("Short-form 'Ref' is deserialized correctly", () => {
+  const value = parseCfnYaml('!Ref Resource');
+
+  expect(value).toEqual({
+    Ref: 'Resource',
+  });
+});
+
+test("Short-form 'Fn::GetAtt' is deserialized correctly", () => {
+  const value = parseCfnYaml('!GetAtt Resource.Attribute');
+
+  expect(value).toEqual({
+    'Fn::GetAtt': 'Resource.Attribute',
+  });
+});
+
+test('Hash merges are not supported', () => {
+  const src = `
+    source: &base { a: 1, b: 2 }
+    target:
+      <<: *base
+      b: base`;
+  const value = parseCfnYaml(src);
+
+  expect(Object.keys(value)).toEqual(['source', 'target']);
+});


### PR DESCRIPTION
fix: dates are parsed as date object, not string
fix: unquoted `.` is parsed as float, not string

--- 

Cause for the issue with unquoted `.` is that the regex for float has a bug that causes `.` to be considered a float. This is actually a bug in the yaml spec as well (or maybe even intentional). 

I decided to add a new tag for unquoted `.`. This seemed to be the least invasive.

However, I'm not entirely convinced it's the best approach to effectively just add a special.

Alternatives are as follow. Aside from fixing the regex, this basically means dropping the float parsing from the yaml parser and doing it ourselves. Which we might not be doing exactly to YAML spec.

- Attempt to patch the buggy regex and replace it with one like this: `/^[-+]?(?:[0-9][0-9_]*\.[0-9_]*|\.[0-9_]+)$/` \
  However the tag is not easily addressable, so we are susceptible to upstream changes. (It's an array and we can really only address it directly by the position in the array)
- Remove the tag. Possible since we do number parsing ourselves later as well. However same addressing issue as above. 
- Remove a larger subset of (or all) float tags. Basically collateral damage because we cannot address the buggy tag directly. Downside is that other possibly valid features like E notation will be removed. Maybe that's a good thing though?