### PR TITLE
fix: `Resources` should be required in template

### DIFF
--- a/cloudformation.schema.json
+++ b/cloudformation.schema.json
@@ -171,6 +171,5 @@
       "type": "object"
     }
   },
-  "required": ["Resources"],
   "type": "object"
 }

--- a/src/parser/template/template.ts
+++ b/src/parser/template/template.ts
@@ -18,9 +18,7 @@ export class Template {
     const tpl = parseCfnYaml(
       await fs.readFile(fileName, { encoding: 'utf-8' })
     );
-    if (!tpl.Resources) {
-      throw new Error(`${fileName}: does not look like a template`);
-    }
+
     return new Template(tpl);
   }
 

--- a/test/evaluate/__snapshots__/fixtures.test.ts.snap
+++ b/test/evaluate/__snapshots__/fixtures.test.ts.snap
@@ -155,6 +155,32 @@ Object {
 }
 `;
 
+exports[`Cloudformation templates cloudformation/condition-using-mapping.json 1`] = `
+Object {
+  "Conditions": Object {
+    "AlwaysTrue": Object {
+      "Fn::Equals": Array [
+        Object {
+          "Fn::FindInMap": Array [
+            "Mapping01",
+            "Key01",
+            "Name",
+          ],
+        },
+        "Value01",
+      ],
+    },
+  },
+  "Mappings": Object {
+    "Mapping01": Object {
+      "Key01": Object {
+        "Name": "Value01",
+      },
+    },
+  },
+}
+`;
+
 exports[`Cloudformation templates cloudformation/custom-resource-with-attributes.json 1`] = `
 Object {
   "Conditions": Object {
@@ -1050,6 +1076,69 @@ Object {
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
+exports[`Cloudformation templates cloudformation/only-parameters-and-rule.json 1`] = `
+Object {
+  "Conditions": Object {
+    "IsProduction": Object {
+      "Fn::Equals": Array [
+        Object {
+          "Ref": "Env",
+        },
+        "prod",
+      ],
+    },
+  },
+  "Parameters": Object {
+    "Env": Object {
+      "Type": "String",
+    },
+    "Subnets": Object {
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+  },
+  "Rules": Object {
+    "TestVpcRule": Object {
+      "Assertions": Array [
+        Object {
+          "Fn::EachMemberIn": Array [
+            Object {
+              "Fn::ValueOfAll": Array [
+                "AWS::EC2::Subnet::Id",
+                "VpcId",
+              ],
+            },
+            Object {
+              "Fn::ValueOf": Array [
+                "Subnets",
+                "VpcId",
+              ],
+            },
+          ],
+        },
+      ],
+      "RuleCondition": Object {
+        "Fn::If": Array [
+          "IsProduction",
+          true,
+          Object {
+            "Fn::Contains": Array [
+              Array [
+                "test",
+                "pre-prod",
+                "preprod",
+              ],
+              Object {
+                "Ref": "Env",
+              },
+            ],
+          },
+        ],
+      },
     },
   },
 }

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -17,7 +17,6 @@ describe('Cloudformation templates', () => {
 
   const ignoreBecauseCurrentlyFailing: string[] = [
     'cloudformation/condition-same-name-as-resource.json', // There is already a Construct with name 'AlwaysTrue' in DeclarativeStack [Test]
-    'cloudformation/condition-using-mapping.json', // does not look like a template
     'cloudformation/find-in-map-for-boolean-property.json', // Expected string or list of strings, got: true
     'cloudformation/find-in-map-with-dynamic-mapping.json', // Expected string, got: {"Ref":"Stage"}
     'cloudformation/fn-sub-escaping.json', //  No resource or parameter with name:  ! DoesNotExist
@@ -26,7 +25,6 @@ describe('Cloudformation templates', () => {
     'cloudformation/functions-and-conditions.json', // Expected list of length 3, got 2
     'cloudformation/hook-code-deploy-blue-green-ecs.json', // Expected valid template, got error(s): -  is not allowed to have the additional property "Hooks"
     'cloudformation/if-in-tags.json', // Expected valid template, got error(s): - Conditions.ValcacheServerEnabled is not of a type(s) object
-    'cloudformation/only-parameters-and-rule.json', // does not look like a template
     'cloudformation/outputs-with-references.json', // Expected string, got: {"Ref":"Bucket"}
     'cloudformation/parameter-references.json', // Expected string or list of strings, got: {"Name":"AWS::Include","Parameters":{"Location":{"Ref":"MyParam"}}}
     'cloudformation/resource-attribute-creation-policy.json', // Expected number, got: {"Ref":"CountParameter"}


### PR DESCRIPTION
We don't enforce templates to be useful, e.g. Resources could have been empty. So let's not limit ourselves with this.
