### PR TITLE
fix: spaces in FnSub literals are causing value to not be a literal

### DIFF
--- a/src/parser/private/sub.ts
+++ b/src/parser/private/sub.ts
@@ -4,23 +4,25 @@ export function analyzeSubPattern(pattern: string): SubFragment[] {
 
   let ph0 = pattern.indexOf('${', start);
   while (ph0 > -1) {
-    if (pattern[ph0 + 2] === '!') {
-      // "${!" means "don't actually substitute"
-      ret.push({ type: 'literal', content: pattern.substring(start, ph0 + 3) });
-      start = ph0 + 3;
-      ph0 = pattern.indexOf('${', start);
-      continue;
-    }
-
     const ph1 = pattern.indexOf('}', ph0 + 2);
+    const placeholder = pattern.substring(ph0 + 2, ph1);
+
     if (ph1 === -1) {
       break;
     }
-    const placeholder = pattern.substring(ph0 + 2, ph1);
 
     if (ph0 > start) {
       ret.push({ type: 'literal', content: pattern.substring(start, ph0) });
     }
+
+    if (placeholder.trim()[0] === '!') {
+      // "${!" means "don't actually substitute"
+      ret.push({ type: 'literal', content: pattern.substring(ph0, ph1 + 1) });
+      start = ph1 + 1;
+      ph0 = pattern.indexOf('${', start);
+      continue;
+    }
+
     if (placeholder.includes('.')) {
       const logicalId = placeholder.split('.')[0];
       // Because split('.', 2) doesn't do what you think it does
@@ -28,7 +30,7 @@ export function analyzeSubPattern(pattern: string): SubFragment[] {
 
       ret.push({ type: 'getatt', logicalId: logicalId!, attr: attr! });
     } else {
-      ret.push({ type: 'ref', logicalId: placeholder });
+      ret.push({ type: 'ref', logicalId: placeholder.trim() });
     }
 
     start = ph1 + 1;

--- a/test/evaluate/__snapshots__/fixtures.test.ts.snap
+++ b/test/evaluate/__snapshots__/fixtures.test.ts.snap
@@ -349,6 +349,23 @@ Object {
 }
 `;
 
+exports[`Cloudformation templates cloudformation/fn-sub-escaping.json 1`] = `
+Object {
+  "Resources": Object {
+    "Bucket": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketName": Object {
+          "Fn::Sub": "some-bucket\${!AWS::AccountId}7896\${ ! DoesNotExist}\${!Immediate}234",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
 exports[`Cloudformation templates cloudformation/fn-sub-map-dotted-attributes.json 1`] = `
 Object {
   "Resources": Object {
@@ -1535,6 +1552,33 @@ Object {
             "region-1",
             "HVMG2",
           ],
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
+exports[`Cloudformation templates cloudformation/short-form-fnsub-string.yaml 1`] = `
+Object {
+  "Resources": Object {
+    "AnotherBucket": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketName": Object {
+          "Fn::Sub": "1-\${AWS::Region}-foo-\${Bucket}-\${!Literal}-\${Bucket.DomainName}-\${AWS::Region}",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Bucket": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketName": Object {
+          "Fn::Sub": "some-bucket\${!AWS::AccountId}7896\${ ! AWS::Region}1-1\${!Immediate}234",
         },
       },
       "Type": "AWS::S3::Bucket",

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -19,7 +19,6 @@ describe('Cloudformation templates', () => {
     'cloudformation/condition-same-name-as-resource.json', // There is already a Construct with name 'AlwaysTrue' in DeclarativeStack [Test]
     'cloudformation/find-in-map-for-boolean-property.json', // Expected string or list of strings, got: true
     'cloudformation/find-in-map-with-dynamic-mapping.json', // Expected string, got: {"Ref":"Stage"}
-    'cloudformation/fn-sub-parsing-edges.json', // TypeError: Cannot read properties of null (reading 'Resources')
     'cloudformation/fn-sub-shadow-attribute.json', //  No resource or parameter with name: AnotherBucket
     'cloudformation/functions-and-conditions.json', // Expected list of length 3, got 2
     'cloudformation/hook-code-deploy-blue-green-ecs.json', // Expected valid template, got error(s): -  is not allowed to have the additional property "Hooks"

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -19,7 +19,6 @@ describe('Cloudformation templates', () => {
     'cloudformation/condition-same-name-as-resource.json', // There is already a Construct with name 'AlwaysTrue' in DeclarativeStack [Test]
     'cloudformation/find-in-map-for-boolean-property.json', // Expected string or list of strings, got: true
     'cloudformation/find-in-map-with-dynamic-mapping.json', // Expected string, got: {"Ref":"Stage"}
-    'cloudformation/fn-sub-escaping.json', //  No resource or parameter with name:  ! DoesNotExist
     'cloudformation/fn-sub-parsing-edges.json', // TypeError: Cannot read properties of null (reading 'Resources')
     'cloudformation/fn-sub-shadow-attribute.json', //  No resource or parameter with name: AnotherBucket
     'cloudformation/functions-and-conditions.json', // Expected list of length 3, got 2
@@ -29,7 +28,6 @@ describe('Cloudformation templates', () => {
     'cloudformation/parameter-references.json', // Expected string or list of strings, got: {"Name":"AWS::Include","Parameters":{"Location":{"Ref":"MyParam"}}}
     'cloudformation/resource-attribute-creation-policy.json', // Expected number, got: {"Ref":"CountParameter"}
     'cloudformation/resource-attribute-update-policy.json', // Expected boolean, got: {"Fn::Equals":["true",{"Ref":"WaitOnResourceSignals"}]}
-    'cloudformation/short-form-fnsub-string.yaml', // No resource or parameter with name:  ! AWS::Region
   ];
 
   testTemplateFixtures(


### PR DESCRIPTION

--- 

Template simplified for brevity.
```json
{
  "Resources": {
    "Bucket": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "Description": { "Fn::Sub": "${!NoSpace}${ ! BothSpace}${! AfterSpace}${ !BeforeSpace}${!EndSpace }" },
      }
    }
  }
}
```
<img width="639" alt="image" src="https://user-images.githubusercontent.com/379814/195660535-64ac9a2d-49ca-4e17-bce7-b0c718dd1527.png">

