### PR TITLE
fix: `StartFleet` CreationPolicy not supported

### DIFF
--- a/src/parser/template/policies.ts
+++ b/src/parser/template/policies.ts
@@ -11,6 +11,7 @@ import { ifField } from './expression';
 export interface CreationPolicy {
   readonly autoScalingCreationPolicy?: AutoScalingCreationPolicy;
   readonly resourceSignal?: ResourceSignal;
+  readonly startFleet?: boolean;
 }
 
 export interface AutoScalingCreationPolicy {
@@ -68,6 +69,7 @@ export function parseCreationPolicy(x: unknown): CreationPolicy | undefined {
       parseAutoScalingCreationPolicy
     ),
     resourceSignal: ifField(policy, 'ResourceSignal', parseResourceSignal),
+    startFleet: ifField(policy, 'StartFleet', assertBoolean),
   };
 }
 

--- a/test/evaluate/resource.test.ts
+++ b/test/evaluate/resource.test.ts
@@ -137,3 +137,25 @@ test('Non-constructs can be instantiated inline using constructor args', async (
     },
   });
 });
+
+describe('CreationPolicy', () => {
+  test('can use StartFleet creation policy', async () => {
+    const parsedTemplate = await Template.fromObject({
+      Resources: {
+        MyBucket: {
+          Type: 'AWS::S3::Bucket',
+          CreationPolicy: {
+            StartFleet: true,
+          },
+        },
+      },
+    });
+
+    const template = await Testing.template(parsedTemplate);
+    template.hasResource('AWS::S3::Bucket', {
+      CreationPolicy: {
+        StartFleet: true,
+      },
+    });
+  });
+});

--- a/test/type-resolution/__snapshots__/fixtures.test.ts.snap
+++ b/test/type-resolution/__snapshots__/fixtures.test.ts.snap
@@ -7613,6 +7613,7 @@ TypedTemplate {
             "count": undefined,
             "timeout": "PT15M",
           },
+          "startFleet": undefined,
         },
         "deletionPolicy": "Delete",
         "dependsOn": Array [],
@@ -8107,6 +8108,7 @@ TypedTemplate {
             "count": undefined,
             "timeout": "PT15M",
           },
+          "startFleet": undefined,
         },
         "deletionPolicy": "Delete",
         "dependencies": Set {
@@ -11614,6 +11616,7 @@ TypedTemplate {
             "count": 3,
             "timeout": "PT15M",
           },
+          "startFleet": undefined,
         },
         "deletionPolicy": "Delete",
         "dependsOn": Array [],
@@ -11812,6 +11815,7 @@ yum update -y aws-cfn-bootstrap
             "count": 3,
             "timeout": "PT15M",
           },
+          "startFleet": undefined,
         },
         "deletionPolicy": "Delete",
         "dependencies": Set {

--- a/test/util.ts
+++ b/test/util.ts
@@ -182,7 +182,11 @@ function resourceErrors(
 ): jsonschema.ValidationError[] {
   return errors.flatMap((e) => {
     const definitions = schema.definitions || {};
-    if (e.path.length !== 2 || e.path[0] !== 'Resources') {
+    if (
+      e.path.length !== 2 ||
+      e.path[0] !== 'Resources' ||
+      !definitions[e.instance.Type]
+    ) {
       return e;
     }
     const local = jsonschema.validate(e.instance, {


### PR DESCRIPTION
Also includes a small fix to the schema errors in tests if a resource type cannot be found.