### PR TITLE
fix: Resources and other types (Conditions, Outputs, etc) cannot have the same name

### DIFF
--- a/test/evaluate/__snapshots__/fixtures.test.ts.snap
+++ b/test/evaluate/__snapshots__/fixtures.test.ts.snap
@@ -155,6 +155,53 @@ Object {
 }
 `;
 
+exports[`Cloudformation templates cloudformation/condition-same-name-as-resource.json 1`] = `
+Object {
+  "Conditions": Object {
+    "AlwaysFalse": Object {
+      "Fn::Equals": Array [
+        Object {
+          "Ref": "Param",
+        },
+        2,
+      ],
+    },
+    "AlwaysTrue": Object {
+      "Fn::Not": Array [
+        Object {
+          "Condition": "AlwaysFalse",
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "Param": Object {
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "AlwaysTrue": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketName": Object {
+          "Fn::If": Array [
+            "AlwaysFalse",
+            Object {
+              "Ref": "Param",
+            },
+            Object {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
 exports[`Cloudformation templates cloudformation/condition-using-mapping.json 1`] = `
 Object {
   "Conditions": Object {
@@ -1274,6 +1321,66 @@ Object {
           },
         ],
       },
+    },
+  },
+}
+`;
+
+exports[`Cloudformation templates cloudformation/outputs-with-references.json 1`] = `
+Object {
+  "Conditions": Object {
+    "AlwaysFalseCond": Object {
+      "Fn::Equals": Array [
+        Object {
+          "Ref": "AWS::Region",
+        },
+        "completely-made-up-region",
+      ],
+    },
+  },
+  "Outputs": Object {
+    "Output1": Object {
+      "Condition": "AlwaysFalseCond",
+      "Description": "a description",
+      "Export": Object {
+        "Name": "Bucket",
+      },
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            Object {
+              "Ref": "MyParam",
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "Bucket",
+                "Arn",
+              ],
+            },
+          ],
+        ],
+      },
+    },
+    "OutputWithNoCondition": Object {
+      "Value": "some-value",
+    },
+  },
+  "Parameters": Object {
+    "MyParam": Object {
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "Bucket": Object {
+      "DeletionPolicy": "Delete",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Output1": Object {
+      "DeletionPolicy": "Delete",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }
@@ -7683,7 +7790,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6babbac1f25446ab4660ead0ad5972e3a7742f50c6d8326af98a8bcd5d485335.zip",
+          "S3Key": "e57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dca.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -8003,31 +8110,6 @@ Object {
             },
             Object {
               "Action": "route53:changeResourceRecordSets",
-              "Condition": Object {
-                "ForAllValues:StringEquals": Object {
-                  "route53:ChangeResourceRecordSetsActions": Array [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": Array [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": Object {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": Array [
-                    Object {
-                      "Fn::Join": Array [
-                        "",
-                        Array [
-                          "*.",
-                          Object {
-                            "Ref": "DomainName",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                },
-              },
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::Join": Array [

--- a/test/evaluate/__snapshots__/fixtures.test.ts.snap
+++ b/test/evaluate/__snapshots__/fixtures.test.ts.snap
@@ -290,6 +290,38 @@ Object {
 }
 `;
 
+exports[`Cloudformation templates cloudformation/find-in-map-for-boolean-property.json 1`] = `
+Object {
+  "Mappings": Object {
+    "SomeMapping": Object {
+      "region": Object {
+        "key1": true,
+      },
+    },
+  },
+  "Resources": Object {
+    "Bucket": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": Object {
+            "Fn::FindInMap": Array [
+              "SomeMapping",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "key1",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
 exports[`Cloudformation templates cloudformation/find-in-map-with-dynamic-mapping.json 1`] = `
 Object {
   "Mappings": Object {
@@ -320,38 +352,6 @@ Object {
             "region",
             "key1",
           ],
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Delete",
-    },
-  },
-}
-`;
-
-exports[`Cloudformation templates cloudformation/find-in-map-for-boolean-property.json 1`] = `
-Object {
-  "Mappings": Object {
-    "SomeMapping": Object {
-      "region": Object {
-        "key1": true,
-      },
-    },
-  },
-  "Resources": Object {
-    "Bucket": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": Object {
-            "Fn::FindInMap": Array [
-              "SomeMapping",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "key1",
-            ],
-          },
         },
       },
       "Type": "AWS::S3::Bucket",
@@ -7790,7 +7790,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dca.zip",
+          "S3Key": "6babbac1f25446ab4660ead0ad5972e3a7742f50c6d8326af98a8bcd5d485335.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -8110,6 +8110,31 @@ Object {
             },
             Object {
               "Action": "route53:changeResourceRecordSets",
+              "Condition": Object {
+                "ForAllValues:StringEquals": Object {
+                  "route53:ChangeResourceRecordSetsActions": Array [
+                    "UPSERT",
+                  ],
+                  "route53:ChangeResourceRecordSetsRecordTypes": Array [
+                    "CNAME",
+                  ],
+                },
+                "ForAllValues:StringLike": Object {
+                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "*.",
+                          Object {
+                            "Ref": "DomainName",
+                          },
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              },
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::Join": Array [

--- a/test/evaluate/fixtures.test.ts
+++ b/test/evaluate/fixtures.test.ts
@@ -16,11 +16,9 @@ describe('Cloudformation templates', () => {
   ]);
 
   const ignoreBecauseCurrentlyFailing: string[] = [
-    'cloudformation/condition-same-name-as-resource.json', // There is already a Construct with name 'AlwaysTrue' in DeclarativeStack [Test]
     'cloudformation/fn-sub-shadow-attribute.json', //  No resource or parameter with name: AnotherBucket
     'cloudformation/functions-and-conditions.json', // Expected list of length 3, got 2
     'cloudformation/hook-code-deploy-blue-green-ecs.json', // Expected valid template, got error(s): -  is not allowed to have the additional property "Hooks"
-    'cloudformation/outputs-with-references.json', // Expected string, got: {"Ref":"Bucket"}
     'cloudformation/parameter-references.json', // Expected string or list of strings, got: {"Name":"AWS::Include","Parameters":{"Location":{"Ref":"MyParam"}}}
     'cloudformation/resource-attribute-creation-policy.json', // Expected number, got: {"Ref":"CountParameter"}
     'cloudformation/resource-attribute-update-policy.json', // Expected boolean, got: {"Fn::Equals":["true",{"Ref":"WaitOnResourceSignals"}]}

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -234,6 +234,30 @@ describe('Parameters', () => {
       BucketName: { Ref: 'BucketName' },
     });
   });
+
+  test('cannot have Resource and Parameter of same name', async () => {
+    // GIVEN
+    const template = await Template.fromObject({
+      Parameters: {
+        TopicOne: {
+          Type: 'String',
+          Default: 'test',
+        },
+      },
+      Resources: {
+        TopicOne: {
+          Type: 'aws-cdk-lib.aws_sns.Topic',
+          Properties: {
+            topicName: 'one',
+            fifo: true,
+          },
+        },
+      },
+    });
+
+    // THEN
+    await expect(Testing.synth(template)).rejects.toThrow();
+  });
 });
 
 describe('given a template with unknown top-level properties', () => {


### PR DESCRIPTION
Fixes #365 