### PR TITLE
feat: allow calls to static factory methods with implicit parameters to be inlined

### DIFF
--- a/src/type-resolution/callables.ts
+++ b/src/type-resolution/callables.ts
@@ -47,7 +47,7 @@ interface InstanceMethodCall extends MethodCall {
   readonly methodPath: string;
 }
 
-function methodFQN(method: reflect.Method): string {
+export function methodFQN(method: reflect.Method): string {
   return `${method.parentType.fqn}.${method.name}`;
 }
 

--- a/src/type-resolution/expression.ts
+++ b/src/type-resolution/expression.ts
@@ -9,7 +9,11 @@ import {
   StringLiteral,
   TemplateExpression,
 } from '../parser/template';
-import { InitializerExpression, StaticMethodCallExpression } from './callables';
+import {
+  InitializerExpression,
+  InstanceMethodCallExpression,
+  StaticMethodCallExpression,
+} from './callables';
 import { EnumExpression, StaticPropertyExpression } from './enums';
 import { DateLiteral } from './literals';
 import { AnyTemplateExpression, VoidExpression } from './primitives';
@@ -31,6 +35,7 @@ export type TypedTemplateExpression =
   | StructExpression
   | StaticPropertyExpression
   | StaticMethodCallExpression
+  | InstanceMethodCallExpression
   | InitializerExpression
   | VoidExpression
   | AnyTemplateExpression


### PR DESCRIPTION
Allow this type of method call:

```yaml
Resources:
  Function:
    Type: aws-cdk-lib.aws_lambda.Function
    Properties:
      runtime: NODEJS_16_X
      handler: 'index.handler'
      code:
        'aws-cdk-lib.aws_lambda.Code.fromInline': 'foo'
      deadLetterQueue:
        # scope and id are inferred here:
        'aws-cdk-lib.aws_sqs.Queue.fromQueueArn': 'arn:aws:sqs:us-east-2:444455556666:queue1'
```

Closes https://github.com/cdklabs/decdk/issues/349.