### PR TITLE
chore: suppress schema warnings for legitimate incompatible interfaces

### DIFF
--- a/src/decdk-schema.ts
+++ b/src/decdk-schema.ts
@@ -17,10 +17,13 @@ async function main() {
     colors: true,
     warnings: argv.warnings,
     suppressWarnings: [
-      // Only an object with methods can satisfy this interface and no built-in class is provided since the feature is intended as an escape hatch
+      // Only an object with methods can satisfy these interfaces and no built-in class is provided
+      // => This feature is intended as an escape hatch
       'aws-cdk-lib.aws_lambda_nodejs.BundlingOptions.commandHooks',
-      // Only an object with methods can satisfy this and no built-in class is provided since the feature is intended for user land functionality
+      // => These features are mostly intended for user land functionality
       'aws-cdk-lib.BundlingOptions.local',
+      'aws-cdk-lib.Lazy.any',
+      'aws-cdk-lib.Lazy.uncachedAny',
     ],
   });
   console.log(JSON.stringify(schema, undefined, 2));

--- a/src/decdk-schema.ts
+++ b/src/decdk-schema.ts
@@ -16,6 +16,12 @@ async function main() {
   const schema = await renderFullSchema(typeSystem, {
     colors: true,
     warnings: argv.warnings,
+    suppressWarnings: [
+      // Only an object with methods can satisfy this interface and no built-in class is provided since the feature is intended as an escape hatch
+      'aws-cdk-lib.aws_lambda_nodejs.BundlingOptions.commandHooks',
+      // Only an object with methods can satisfy this and no built-in class is provided since the feature is intended for user land functionality
+      'aws-cdk-lib.BundlingOptions.local',
+    ],
   });
   console.log(JSON.stringify(schema, undefined, 2));
 }

--- a/src/schema/cdk-schema.ts
+++ b/src/schema/cdk-schema.ts
@@ -12,10 +12,21 @@ import { schemaForRules } from './rules';
 /* eslint-disable no-console */
 
 export interface RenderSchemaOptions {
+  /**
+   * Show warnings for the generated schema.
+   * @default false
+   */
   warnings?: boolean;
 
   /**
-   * Use colors when printing ouput.
+   * Suppress specific warnings in the warnings output.
+   * Should only be used for known issues that are expected to create a warning due to their incompatibility with declarative style.
+   * @default []
+   */
+  suppressWarnings?: string[];
+
+  /**
+   * Use colors when printing output.
    * @default true if tty is enabled
    */
   colors?: boolean;
@@ -135,7 +146,7 @@ export function renderFullSchema(
   };
 
   if (options.warnings) {
-    printWarnings(ctx);
+    printWarnings(ctx, options.suppressWarnings ?? []);
   }
 
   function addResource(resource?: { $ref: string }) {
@@ -153,8 +164,8 @@ export function renderFullSchema(
   return output;
 }
 
-function printWarnings(node: SchemaContext, indent = '') {
-  if (!node.hasWarningsOrErrors) {
+function printWarnings(node: SchemaContext, suppress: string[], indent = '') {
+  if (!node.hasWarningsOrErrors(suppress)) {
     return;
   }
 
@@ -173,7 +184,7 @@ function printWarnings(node: SchemaContext, indent = '') {
   }
 
   for (const child of node.children) {
-    printWarnings(child, indent);
+    printWarnings(child, suppress, indent);
   }
 }
 

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -514,9 +514,13 @@ export function schemaForEnumLikeClass(
 }
 
 function methodSchema(method: reflect.Callable, ctx: SchemaContext) {
-  ctx = ctx.child('method', method.name);
-
   const fqn = `${method.parentType.fqn}.${method.name}`;
+
+  ctx = ctx.child(
+    'method',
+    fqn,
+    ctx.fqn === method.parentType.fqn ? method.name : undefined
+  );
 
   const methodctx = ctx;
 

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -528,12 +528,15 @@ function methodSchema(method: reflect.Callable, ctx: SchemaContext) {
     const properties: any[] = [];
     const required = new Array<string>();
 
-    const addProperty = (prop: reflect.Property | reflect.Parameter): void => {
-      const param = schemaForTypeReference(prop.type, ctx);
+    const addProperty = (
+      prop: reflect.Property | reflect.Parameter,
+      propCtx: SchemaContext
+    ): void => {
+      const param = schemaForTypeReference(prop.type, propCtx);
 
       // bail out - can't serialize a required parameter, so we can't serialize the method
       if (!param && !prop.optional) {
-        ctx.error(
+        propCtx.error(
           'cannot schematize method because parameter cannot be schematized'
         );
         return undefined;
@@ -548,9 +551,9 @@ function methodSchema(method: reflect.Callable, ctx: SchemaContext) {
 
     for (let i = 0; i < method.parameters.length; ++i) {
       const p = method.parameters[i];
-      methodctx.child('param', p.name);
+      const propCtx = methodctx.child('param', p.name);
 
-      addProperty(p);
+      addProperty(p, propCtx);
     }
 
     const basicSchema =

--- a/src/schema/jsii2schema.ts
+++ b/src/schema/jsii2schema.ts
@@ -556,6 +556,16 @@ function methodSchema(method: reflect.Callable, ctx: SchemaContext) {
       addProperty(p, propCtx);
     }
 
+    const requiredParams = method.parameters.filter((p) => !p.optional);
+    if (
+      requiredParams.length > 0 &&
+      requiredParams.length !== required.length
+    ) {
+      // If at least one required parameter cannot be schematized,
+      // the whole method cannot be schematized.
+      return;
+    }
+
     const basicSchema =
       required.length > 0
         ? {


### PR DESCRIPTION
Suppresses 3 warnings about legitimately incompatible interfaces. We should not display these warnings to users.
Also improves the usefullness of warnings. In some cases the provided context/name was skipping important info.
Finally, removes the (empty) schema for methods that are not schematizable.

Releated to #63 

----

Was:
```
[impl "aws-cdk-lib.SecretValue"]
  [method "any"]
    didn't match any schematizable shape
    cannot schematize method because parameter cannot be schematized
```
Now:
```
[impl "aws-cdk-lib.SecretValue"]
  [method "aws-cdk-lib.Lazy.any"]
    [param "producer"]
      didn't match any schematizable shape
      cannot schematize method because parameter cannot be schematized
```