### PR TITLE
feat: CDK context moved to the `Metadata` section.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "npm-check-updates": "^16",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
-    "projen": "^0.64.0",
+    "projen": "^0.64.1",
     "standard-version": "^9",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -19,7 +19,8 @@ export class DeclarativeStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: DeclarativeStackProps) {
     super(scope, id, props);
 
-    props.template.context.forEach((v, k) => this.node.setContext(k, v));
+    const ctx = props.template.metadata.get('AWS::CDK::Context') ?? {};
+    Object.entries(ctx).forEach(([k, v]) => this.node.setContext(k, v));
 
     this.templateOptions.templateFormatVersion =
       props.template.templateFormatVersion;

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -104,21 +104,9 @@ export class Evaluator {
   }
 
   private evaluateMetadata() {
-    const metadata = this.context.template.metadata;
-    if (metadata.size > 0) {
-      // Just in case some construct has already added metadata
-      const existingMetadata =
-        this.context.stack.templateOptions.metadata ?? {};
-
-      const newMetadata = Object.fromEntries(
-        [...metadata.entries()].map(([k, v]) => [k, this.evaluate(v)])
-      );
-
-      this.context.stack.templateOptions.metadata = {
-        ...existingMetadata,
-        ...newMetadata,
-      };
-    }
+    this.context.template.metadata.forEach((v, k) => {
+      this.context.stack.addMetadata(k, v);
+    });
   }
 
   private evaluateRules() {

--- a/src/parser/template/template.ts
+++ b/src/parser/template/template.ts
@@ -41,10 +41,9 @@ export class Template {
   public readonly mappings: Map<string, TemplateMapping>;
   public readonly outputs: Map<string, TemplateOutput>;
   public readonly transform: string[];
-  public readonly metadata: Map<string, TemplateExpression>;
+  public readonly metadata: Map<string, unknown>;
   public readonly rules: Map<string, TemplateRule>;
   public readonly hooks: Map<string, TemplateHook>;
-  public readonly context: Map<string, any>;
 
   constructor(public template: schema.Template) {
     this.templateFormatVersion = template.AWSTemplateFormatVersion;
@@ -55,10 +54,9 @@ export class Template {
     this.mappings = mapValues(template.Mappings, parseMapping);
     this.outputs = mapValues(template.Outputs, parseOutput);
     this.transform = parseTransform(template.Transform);
-    this.metadata = mapValues(template.Metadata, parseExpression);
+    this.metadata = mapValues(template.Metadata, identity);
     this.rules = mapValues(template.Rules, parseRule);
     this.hooks = mapValues(template.Hooks, parseHook);
-    this.context = mapValues(template.Context, (v) => v);
   }
 
   public resource(logicalId: string) {
@@ -108,4 +106,8 @@ function mapEntries<T, U>(
   fn: (key: string, t: T) => U
 ): Map<string, U> {
   return new Map(Object.entries(record ?? {}).map(([k, v]) => [k, fn(k, v)]));
+}
+
+function identity<T>(v: T): T {
+  return v;
 }

--- a/src/type-resolution/template.ts
+++ b/src/type-resolution/template.ts
@@ -1,10 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { DependencyGraph } from '../parser/private/toposort';
-import {
-  Template,
-  TemplateExpression,
-  TemplateParameter,
-} from '../parser/template';
+import { Template, TemplateParameter } from '../parser/template';
 import { TemplateHook } from '../parser/template/hooks';
 import { TemplateMapping } from '../parser/template/mappings';
 import { TemplateRule } from '../parser/template/rules';
@@ -29,7 +25,7 @@ export class TypedTemplate {
   public readonly mappings: Map<string, TemplateMapping>;
   public readonly outputs: Map<string, TypedTemplateOutput>;
   public readonly transform: string[];
-  public readonly metadata: Map<string, TemplateExpression>;
+  public readonly metadata: Map<string, unknown>;
   public readonly rules: Map<string, TemplateRule>;
   public readonly hooks: Map<string, TemplateHook>;
 

--- a/test/evaluate/template.test.ts
+++ b/test/evaluate/template.test.ts
@@ -776,6 +776,10 @@ suite('Metadata', () => {
 
 suite('Context', () => {
   test('Feature flags are applied', async () => {
+    expect(await resourceNames()).toContain(
+      'ApiUsagePlanUsagePlanKeyResourceTestApiApiKeyB8A9B490D8F8A61F'
+    );
+
     expect(
       await resourceNames({
         '@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId': true,
@@ -790,9 +794,10 @@ suite('Context', () => {
       })
     ).toContain('ApiUsagePlanUsagePlanKeyResource7792961C');
 
-    async function resourceNames(context: Record<string, any>) {
+    async function resourceNames(context?: unknown) {
       const template = await Testing.template(
         await Template.fromObject({
+          Metadata: { 'AWS::CDK::Context': context },
           Resources: {
             Api: {
               Type: 'aws-cdk-lib.aws_apigateway.RestApi',
@@ -842,7 +847,6 @@ suite('Context', () => {
               Call: ['Plan', { addApiKey: { Ref: 'Key' } }],
             },
           },
-          Context: context,
         }),
         { validateTemplate: false }
       );

--- a/test/type-resolution/__snapshots__/fixtures.test.ts.snap
+++ b/test/type-resolution/__snapshots__/fixtures.test.ts.snap
@@ -125,7 +125,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a lambda function with an api gateway",
     "hooks": Map {},
     "mappings": Map {},
@@ -574,7 +573,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -1124,7 +1122,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a Fargate service with necessary resources",
     "hooks": Map {},
     "mappings": Map {},
@@ -1453,7 +1450,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates an ASG and Vpc",
     "hooks": Map {},
     "mappings": Map {},
@@ -1774,7 +1770,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -2514,7 +2509,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -3293,7 +3287,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a lambda function which can be invoked by an sns topic",
     "hooks": Map {},
     "mappings": Map {},
@@ -3628,7 +3621,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a aws cli lambda layer",
     "hooks": Map {},
     "mappings": Map {},
@@ -3923,7 +3915,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -4268,7 +4259,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -4677,7 +4667,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a CodePipeline along with its CodeCommit repository source",
     "hooks": Map {},
     "mappings": Map {},
@@ -5559,7 +5548,6 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -6227,7 +6215,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -7779,7 +7766,6 @@ TypedTemplate {
         "type": "intrinsic",
       },
     },
-    "context": Map {},
     "description": "AWS CloudFormation Sample Template for using Assertions: Create a load balanced, Auto Scaled sample website where the instances are locked down to only accept traffic from the load balancer. This example creates an Auto Scaling group behind a load balancer with a health check. The web site is available on port 80 or 443 based on the input.",
     "hooks": Map {},
     "mappings": Map {
@@ -10011,7 +9997,6 @@ TypedTemplate {
         },
       },
     },
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -10415,7 +10400,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {
@@ -10522,22 +10506,10 @@ TypedTemplate {
   "mappings": Map {},
   "metadata": Map {
     "Instances" => Object {
-      "fields": Object {
-        "Description": Object {
-          "type": "string",
-          "value": "Information about the instances",
-        },
-      },
-      "type": "object",
+      "Description": "Information about the instances",
     },
     "Databases" => Object {
-      "fields": Object {
-        "Description": Object {
-          "type": "string",
-          "value": "Information about the databases",
-        },
-      },
-      "type": "object",
+      "Description": "Information about the databases",
     },
   },
   "outputs": Map {},
@@ -10575,28 +10547,15 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
     "metadata": Map {
       "Instances" => Object {
-        "fields": Object {
-          "Description": Object {
-            "type": "string",
-            "value": "Information about the instances",
-          },
-        },
-        "type": "object",
+        "Description": "Information about the instances",
       },
       "Databases" => Object {
-        "fields": Object {
-          "Description": Object {
-            "type": "string",
-            "value": "Information about the databases",
-          },
-        },
-        "type": "object",
+        "Description": "Information about the databases",
       },
     },
     "outputs": Map {},
@@ -10786,7 +10745,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -11081,7 +11039,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a lambda function with an api gateway",
     "hooks": Map {},
     "mappings": Map {},
@@ -11369,7 +11326,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -11831,7 +11787,6 @@ yum update -y aws-cfn-bootstrap
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -12186,7 +12141,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -12246,22 +12200,10 @@ TypedTemplate {
   "mappings": Map {},
   "metadata": Map {
     "Instances" => Object {
-      "fields": Object {
-        "Description": Object {
-          "type": "string",
-          "value": "Information about the instances",
-        },
-      },
-      "type": "object",
+      "Description": "Information about the instances",
     },
     "Databases" => Object {
-      "fields": Object {
-        "Description": Object {
-          "type": "string",
-          "value": "Information about the databases",
-        },
-      },
-      "type": "object",
+      "Description": "Information about the databases",
     },
   },
   "outputs": Map {},
@@ -12306,28 +12248,15 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
     "metadata": Map {
       "Instances" => Object {
-        "fields": Object {
-          "Description": Object {
-            "type": "string",
-            "value": "Information about the instances",
-          },
-        },
-        "type": "object",
+        "Description": "Information about the instances",
       },
       "Databases" => Object {
-        "fields": Object {
-          "Description": Object {
-            "type": "string",
-            "value": "Information about the databases",
-          },
-        },
-        "type": "object",
+        "Description": "Information about the databases",
       },
     },
     "outputs": Map {},
@@ -12473,7 +12402,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -12789,7 +12717,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": "A template creates a lambda function which can be invoked by an sns topic",
     "hooks": Map {},
     "mappings": Map {},
@@ -13189,7 +13116,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -13741,7 +13667,6 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},
@@ -14662,7 +14587,6 @@ TypedTemplate {
   "rules": Map {},
   "template": Template {
     "conditions": Map {},
-    "context": Map {},
     "description": undefined,
     "hooks": Map {},
     "mappings": Map {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,9 +1339,9 @@ camelcase@^7.0.0:
   integrity sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001423"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz#57176d460aa8cd85ee1a72016b961eb9aca55d91"
-  integrity sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==
+  version "1.0.30001425"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz#52917791a453eb3265143d2cd08d80629e82c735"
+  integrity sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==
 
 case@1.6.3, case@^1.6.3:
   version "1.6.3"
@@ -4430,10 +4430,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.64.0.tgz#dccadc98549673aa19ec0d76a7e4494a1816ae5e"
-  integrity sha512-gPh3J44V2y9DgFm8X+g0DVlaliyO6KV8Ztlehu4/F4yc5p9J0njw7vyy8XMDz4jfxN2wfP2KQSHm8eIIzuQa9w==
+projen@^0.64.1:
+  version "0.64.1"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.64.1.tgz#6148aee0657c31f97e884a781e9c0f7c565abc69"
+  integrity sha512-fiAX1QwOcJlGdvXtzrx6ZMUKUAOf2/QleL+FsZCfJB20K2JO/q+3P0QGLW9spcHbJQ3xRqw35Wjr7JTVZaL8DA==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
This will avoid name clashes with CloudFormation in the future, in case they decide to add a new top-level section with the same name.