### PR TITLE
chore: aws-cdk-lib as peer dependency so consumers can define their own version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -37,6 +37,10 @@
       "type": "build"
     },
     {
+      "name": "aws-cdk-lib",
+      "type": "build"
+    },
+    {
       "name": "eslint-config-prettier",
       "type": "build"
     },
@@ -127,7 +131,8 @@
     },
     {
       "name": "aws-cdk-lib",
-      "type": "runtime"
+      "version": "^2.1.0",
+      "type": "peer"
     },
     {
       "name": "chalk",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -11,7 +11,6 @@ const project = new typescript.TypeScriptProject({
   authorOrganization: true,
   prerelease: 'pre',
   deps: [
-    'aws-cdk-lib',
     'constructs@^10',
     'fs-extra@^8',
     'jsii-reflect',
@@ -26,9 +25,14 @@ const project = new typescript.TypeScriptProject({
     '@types/semver',
     '@types/yaml',
     '@types/yargs',
+    'aws-cdk-lib',
     'jsii',
     'fast-check',
   ],
+  peerDeps: ['aws-cdk-lib@^2.1.0'],
+  peerDependencyOptions: {
+    pinnedDevDependency: false,
+  },
   releaseFailureIssue: true,
   releaseToNpm: true,
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/yargs": "^17.0.13",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
+    "aws-cdk-lib": "^2.47.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
@@ -58,8 +59,10 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
   },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.1.0"
+  },
   "dependencies": {
-    "aws-cdk-lib": "^2.47.0",
     "chalk": "^4",
     "constructs": "^10",
     "fs-extra": "^8",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as jsiiReflect from 'jsii-reflect';
+import * as reflect from 'jsii-reflect';
 import { Template } from './parser/template';
 
 /**
@@ -10,7 +10,7 @@ export async function readTemplate(templateFile: string): Promise<Template> {
 }
 
 export async function loadTypeSystem(validate = true) {
-  const typeSystem = new jsiiReflect.TypeSystem();
+  const typeSystem = new reflect.TypeSystem();
   await typeSystem.loadNpmDependencies(path.resolve(__dirname, '..'), {
     validate,
   });


### PR DESCRIPTION
Changes `aws-cdk-lib` to be a peer dependency with very loose version constraint and then adds it as a dev depdendency with tight version constraint.

The change to the schema are changes in ordering only.

Fixes #351 in the sense that decdk now doesn't limit versions of aws0cdk core anymore.