### PR TITLE
feat: collect errors

### DIFF
--- a/src/decdk.ts
+++ b/src/decdk.ts
@@ -2,7 +2,10 @@ import * as cdk from 'aws-cdk-lib';
 import chalk from 'chalk';
 import yargs from 'yargs';
 import { DeclarativeStack } from './declarative-stack';
+import { DeclarativeStackError } from './error-handling';
 import { loadTypeSystem, readTemplate, stackNameFromFileName } from './util';
+
+let verbosity = 0;
 
 async function main() {
   const argv = await yargs
@@ -10,7 +13,14 @@ async function main() {
       '$0 <filename>',
       'Synthesize a CDK stack from a declarative JSON or YAML template'
     )
+    .option('verbose', {
+      alias: 'v',
+      type: 'count',
+      description: 'Show debug output. Repeat to increase verbosity.',
+    })
     .positional('filename', { type: 'string', required: true }).argv;
+
+  verbosity = argv.verbose;
 
   const templateFile = argv.filename;
   if (!templateFile) {
@@ -35,6 +45,9 @@ async function main() {
 }
 
 main().catch((e) => {
+  if (e instanceof DeclarativeStackError) {
+    e = e.toString(verbosity >= 1);
+  }
   // eslint-disable-next-line no-console
   console.error(chalk.red(e));
   process.exit(1);

--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -1,8 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as reflect from 'jsii-reflect';
+import { AnnotationsContext, DeclarativeStackError } from './error-handling';
 import { EvaluationContext, Evaluator } from './evaluate';
-import { AnnotationsContext, DeclarativeStackError } from './evaluate/errors';
 import { Template } from './parser/template';
 import { TypedTemplate } from './type-resolution/template';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -43,7 +43,6 @@ export class DeclarativeStack extends cdk.Stack {
       stack: this,
       template,
       typeSystem,
-      annotations,
     });
     const ev = new Evaluator(context);
 
@@ -51,8 +50,8 @@ export class DeclarativeStack extends cdk.Stack {
       ev.evaluateTemplate(annotations);
     });
 
-    if (context.annotations.hasErrors()) {
-      throw new DeclarativeStackError(context.annotations);
+    if (annotations.hasErrors()) {
+      throw new DeclarativeStackError(annotations);
     }
   }
 }

--- a/src/error-handling/annotations.ts
+++ b/src/error-handling/annotations.ts
@@ -1,30 +1,4 @@
-export class DeclarativeStackError extends Error {
-  constructor(public readonly annotations: AnnotationsContext) {
-    super();
-    this.name = 'Declarative CDK Errors';
-    Object.setPrototypeOf(this, DeclarativeStackError.prototype);
-  }
-
-  public toString() {
-    return `${this.name}:\n\n${this.annotations.toString()}`;
-  }
-}
-
-export class RuntimeError extends Error {
-  constructor(msg: string) {
-    super(msg);
-    this.name = 'RuntimeError';
-    Object.setPrototypeOf(this, RuntimeError.prototype);
-  }
-}
-
-class AnnotatedError {
-  constructor(public readonly path: string, public readonly error: Error) {}
-
-  public toString() {
-    return `[${this.path}] ${this.error}`;
-  }
-}
+import { AnnotatedError } from './errors';
 
 export class AnnotationsContext {
   public static root(): AnnotationsContext {
@@ -61,9 +35,9 @@ export class AnnotationsContext {
     return new AnnotationsContext(this, path);
   }
 
-  public wrap(fn: (ctx: AnnotationsContext) => void) {
+  public wrap<T>(fn: (ctx: AnnotationsContext) => T): T | void {
     try {
-      fn(this);
+      return fn(this);
     } catch (error) {
       this.error(error as any);
     }
@@ -77,7 +51,7 @@ export class AnnotationsContext {
     logger(this.toString());
   }
 
-  public toString() {
-    return this.errors.map((e) => e.toString()).join('\n');
+  public toString(printStackStrace = false) {
+    return this.errors.map((e) => e.toString(printStackStrace)).join('\n');
   }
 }

--- a/src/error-handling/annotations.ts
+++ b/src/error-handling/annotations.ts
@@ -6,18 +6,18 @@ export class AnnotationsContext {
   }
 
   public readonly children = new Array<AnnotationsContext>();
-  public readonly path: string[] = [];
+  public readonly path: Array<string | number> = [];
   public readonly parent?: AnnotationsContext;
   private readonly _errorsStack: AnnotatedError[] = [];
 
-  private constructor(parent?: AnnotationsContext, path?: string) {
+  private constructor(parent?: AnnotationsContext, path?: string | number) {
     if (parent) {
       this.path.push(...parent.path);
       this.parent = parent;
       parent.children.push(this);
     }
 
-    if (path) {
+    if (path !== undefined) {
       this.path.push(path);
     }
   }
@@ -34,7 +34,7 @@ export class AnnotationsContext {
     return [...this._errorsStack, ...this.children.flatMap((c) => c.errors)];
   }
 
-  public child(path: string): AnnotationsContext {
+  public child(path: string | number): AnnotationsContext {
     return new AnnotationsContext(this, path);
   }
 

--- a/src/error-handling/annotations.ts
+++ b/src/error-handling/annotations.ts
@@ -6,16 +6,19 @@ export class AnnotationsContext {
   }
 
   public readonly children = new Array<AnnotationsContext>();
-  public readonly path: string;
+  public readonly path: string[] = [];
   public readonly parent?: AnnotationsContext;
   private readonly _errorsStack: AnnotatedError[] = [];
 
   private constructor(parent?: AnnotationsContext, path?: string) {
-    this.path = path || '';
     if (parent) {
-      this.path = parent.path ? parent.path + '.' + this.path : this.path;
+      this.path.push(...parent.path);
       this.parent = parent;
       parent.children.push(this);
+    }
+
+    if (path) {
+      this.path.push(path);
     }
   }
 
@@ -47,11 +50,7 @@ export class AnnotationsContext {
     this._errorsStack.push(new AnnotatedError(this.path, error));
   }
 
-  public printErrors(logger: Console['log']) {
-    logger(this.toString());
-  }
-
   public toString(printStackStrace = false) {
-    return this.errors.map((e) => e.toString(printStackStrace)).join('\n');
+    return this.errors.map((e) => e.toString(printStackStrace)).join('\n\n');
   }
 }

--- a/src/error-handling/errors.ts
+++ b/src/error-handling/errors.ts
@@ -1,0 +1,35 @@
+import { AnnotationsContext } from './annotations';
+
+export class DeclarativeStackError extends Error {
+  constructor(public readonly annotations: AnnotationsContext) {
+    super();
+    this.name = 'Declarative CDK Errors';
+    Object.setPrototypeOf(this, DeclarativeStackError.prototype);
+  }
+
+  public toString(debug = false) {
+    return `${this.name}:\n\n${this.annotations.toString(debug)}`;
+  }
+}
+
+/**
+ * Thrown by the Evaluator
+ */
+export class RuntimeError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'RuntimeError';
+    Object.setPrototypeOf(this, RuntimeError.prototype);
+  }
+}
+
+/**
+ * Annotation any Error with additional info
+ */
+export class AnnotatedError {
+  constructor(public readonly path: string, public readonly error: Error) {}
+
+  public toString(printStackStrace = false) {
+    return `[${this.path}] ${printStackStrace ? this.error.stack : this.error}`;
+  }
+}

--- a/src/error-handling/errors.ts
+++ b/src/error-handling/errors.ts
@@ -1,9 +1,18 @@
 import { AnnotationsContext } from './annotations';
 
+function indent(text: string, spaces = 4) {
+  const TAB = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((l) => TAB + l)
+    .join('\n');
+}
+
 export class DeclarativeStackError extends Error {
   constructor(public readonly annotations: AnnotationsContext) {
     super();
-    this.name = 'Declarative CDK Errors';
+    this.name = 'DeclarativeStackError';
+    this.message = this.toString();
     Object.setPrototypeOf(this, DeclarativeStackError.prototype);
   }
 
@@ -37,12 +46,18 @@ export class AnnotatedError {
   constructor(public readonly stack: string[], public readonly error: Error) {}
 
   public toString(printStackStrace = false) {
-    return `[${this.error.name} at ${this.renderStack()}]\n    ${
-      printStackStrace ? this.error.stack : this.error.message
-    }`;
+    const details = this.renderErrorDetails(printStackStrace);
+    return `[${this.error.name} at ${this.renderStack()}]\n${indent(details)}`;
   }
 
-  protected renderStack() {
+  protected renderErrorDetails(printStackStrace = false): string {
+    if (printStackStrace) {
+      return this.error.stack ?? this.error.message;
+    }
+    return this.error.message;
+  }
+
+  protected renderStack(): string {
     return this.stack.map((s) => (s.includes('.') ? `"${s}"` : s)).join('.');
   }
 }

--- a/src/error-handling/errors.ts
+++ b/src/error-handling/errors.ts
@@ -43,7 +43,10 @@ export class RuntimeError extends Error {
  * Annotation any Error with additional info
  */
 export class AnnotatedError {
-  constructor(public readonly stack: string[], public readonly error: Error) {}
+  constructor(
+    public readonly stack: Array<string | number>,
+    public readonly error: Error
+  ) {}
 
   public toString(printStackStrace = false) {
     const details = this.renderErrorDetails(printStackStrace);
@@ -58,6 +61,8 @@ export class AnnotatedError {
   }
 
   protected renderStack(): string {
-    return this.stack.map((s) => (s.includes('.') ? `"${s}"` : s)).join('.');
+    return this.stack
+      .map((s) => (s.toString().includes('.') ? `"${s}"` : s))
+      .join('.');
   }
 }

--- a/src/error-handling/errors.ts
+++ b/src/error-handling/errors.ts
@@ -16,9 +16,16 @@ export class DeclarativeStackError extends Error {
  * Thrown by the Evaluator
  */
 export class RuntimeError extends Error {
-  constructor(msg: string) {
-    super(msg);
+  public static wrap(error: any) {
+    return new RuntimeError(error.message, error.stack);
+  }
+
+  constructor(message: string, stack?: string) {
+    super(message);
     this.name = 'RuntimeError';
+    if (stack) {
+      this.stack = stack;
+    }
     Object.setPrototypeOf(this, RuntimeError.prototype);
   }
 }
@@ -27,9 +34,15 @@ export class RuntimeError extends Error {
  * Annotation any Error with additional info
  */
 export class AnnotatedError {
-  constructor(public readonly path: string, public readonly error: Error) {}
+  constructor(public readonly stack: string[], public readonly error: Error) {}
 
   public toString(printStackStrace = false) {
-    return `[${this.path}] ${printStackStrace ? this.error.stack : this.error}`;
+    return `[${this.error.name} at ${this.renderStack()}]\n    ${
+      printStackStrace ? this.error.stack : this.error.message
+    }`;
+  }
+
+  protected renderStack() {
+    return this.stack.map((s) => (s.includes('.') ? `"${s}"` : s)).join('.');
   }
 }

--- a/src/error-handling/index.ts
+++ b/src/error-handling/index.ts
@@ -1,0 +1,3 @@
+export * from './annotations';
+export * from './errors';
+export * from './unparse';

--- a/src/error-handling/unparse.ts
+++ b/src/error-handling/unparse.ts
@@ -1,0 +1,28 @@
+import {
+  INTRINSIC_NAME_MAP,
+  TemplateExpression,
+  UserIntrinsicExpression,
+} from '../parser/template';
+
+export function unparseExpression(x: TemplateExpression): any {
+  switch (x.type) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return x.value;
+    case 'null':
+      return null;
+    case 'array':
+      return x.array.map(unparseExpression);
+    case 'object':
+      return Object.fromEntries(
+        Object.entries(x.fields).map(([k, v]) => [k, unparseExpression(v)])
+      );
+    default:
+      return x;
+  }
+}
+
+export function intrinsicToLongForm(fn: UserIntrinsicExpression['fn']): string {
+  return INTRINSIC_NAME_MAP?.[fn] ?? fn;
+}

--- a/src/evaluate/context.ts
+++ b/src/evaluate/context.ts
@@ -1,16 +1,19 @@
 import * as cdk from 'aws-cdk-lib';
 import * as reflect from 'jsii-reflect';
 import { TypedTemplate } from '../type-resolution/template';
+import { AnnotationsContext } from './errors';
 import { InstanceReference, Reference, References } from './references';
 
 export interface EvaluationContextOptions {
   readonly stack: cdk.Stack;
   readonly template: TypedTemplate;
   readonly typeSystem: reflect.TypeSystem;
+  readonly annotations?: AnnotationsContext;
 }
 class PseudoParamRef extends InstanceReference {}
 
 export class EvaluationContext {
+  public readonly annotations: AnnotationsContext;
   public readonly stack: cdk.Stack;
   public readonly typeSystem: reflect.TypeSystem;
   public readonly template: TypedTemplate;
@@ -20,6 +23,7 @@ export class EvaluationContext {
     this.stack = opts.stack;
     this.template = opts.template;
     this.typeSystem = opts.typeSystem;
+    this.annotations = opts.annotations ?? AnnotationsContext.root();
 
     this.addReferences(
       new PseudoParamRef('AWS::AccountId', cdk.Aws.ACCOUNT_ID),

--- a/src/evaluate/errors.ts
+++ b/src/evaluate/errors.ts
@@ -1,0 +1,83 @@
+export class DeclarativeStackError extends Error {
+  constructor(public readonly annotations: AnnotationsContext) {
+    super();
+    this.name = 'Declarative CDK Errors';
+    Object.setPrototypeOf(this, DeclarativeStackError.prototype);
+  }
+
+  public toString() {
+    return `${this.name}:\n\n${this.annotations.toString()}`;
+  }
+}
+
+export class RuntimeError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'RuntimeError';
+    Object.setPrototypeOf(this, RuntimeError.prototype);
+  }
+}
+
+class AnnotatedError {
+  constructor(public readonly path: string, public readonly error: Error) {}
+
+  public toString() {
+    return `[${this.path}] ${this.error}`;
+  }
+}
+
+export class AnnotationsContext {
+  public static root(): AnnotationsContext {
+    return new AnnotationsContext();
+  }
+
+  public readonly children = new Array<AnnotationsContext>();
+  public readonly path: string;
+  public readonly parent?: AnnotationsContext;
+  private readonly _errorsStack: AnnotatedError[] = [];
+
+  private constructor(parent?: AnnotationsContext, path?: string) {
+    this.path = path || '';
+    if (parent) {
+      this.path = parent.path ? parent.path + '.' + this.path : this.path;
+      this.parent = parent;
+      parent.children.push(this);
+    }
+  }
+
+  public get root(): boolean {
+    return !!this.parent;
+  }
+
+  public hasErrors(): boolean {
+    return this.errors.length > 0;
+  }
+
+  public get errors(): AnnotatedError[] {
+    return [...this._errorsStack, ...this.children.flatMap((c) => c.errors)];
+  }
+
+  public child(path: string): AnnotationsContext {
+    return new AnnotationsContext(this, path);
+  }
+
+  public wrap(fn: (ctx: AnnotationsContext) => void) {
+    try {
+      fn(this);
+    } catch (error) {
+      this.error(error as any);
+    }
+  }
+
+  public error(error: Error) {
+    this._errorsStack.push(new AnnotatedError(this.path, error));
+  }
+
+  public printErrors(logger: Console['log']) {
+    logger(this.toString());
+  }
+
+  public toString() {
+    return this.errors.map((e) => e.toString()).join('\n');
+  }
+}

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -234,7 +234,7 @@ export class Evaluator {
           return this.invoke(x, ctx);
       }
     } catch (error) {
-      ctx.error(new RuntimeError((error as any).message));
+      ctx.error(RuntimeError.wrap(error));
     }
   }
 

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -9,10 +9,16 @@ import {
   Token,
 } from 'aws-cdk-lib';
 import { Construct, IConstruct } from 'constructs';
+import {
+  AnnotationsContext,
+  RuntimeError,
+  intrinsicToLongForm,
+} from '../error-handling';
 import { SubFragment } from '../parser/private/sub';
 import { assertString } from '../parser/private/types';
 import {
   GetPropIntrinsic,
+  IntrinsicExpression,
   LazyLogicalId,
   RefIntrinsic,
 } from '../parser/template';
@@ -29,10 +35,12 @@ import {
   InstanceMethodCallExpression,
   StaticMethodCallExpression,
 } from '../type-resolution/callables';
-import { TypedTemplateExpression } from '../type-resolution/expression';
+import {
+  TypedArrayExpression,
+  TypedTemplateExpression,
+} from '../type-resolution/expression';
 import { ResolveReferenceExpression } from '../type-resolution/references';
 import { EvaluationContext } from './context';
-import { AnnotationsContext, RuntimeError } from './errors';
 import { DeCDKCfnOutput } from './outputs';
 import { applyOverride } from './overrides';
 import {
@@ -48,28 +56,30 @@ export class Evaluator {
 
   public evaluateTemplate(ctx: AnnotationsContext) {
     this.evaluateParameters(ctx.child('Parameters'));
-    this.evaluateMetadata();
-    this.evaluateRules();
-    this.evaluateMappings();
-    this.evaluateConditions();
-    this.evaluateTransform();
+    this.evaluateMetadata(ctx.child('Metadata'));
+    this.evaluateRules(ctx.child('Rules'));
+    this.evaluateMappings(ctx.child('Mappings'));
+    this.evaluateConditions(ctx.child('Conditions'));
+    this.evaluateTransform(ctx.child('Transform'));
     this.evaluateResources(ctx.child('Resources'));
-    this.evaluateOutputs();
-    this.evaluateHooks();
+    this.evaluateOutputs(ctx.child('Outputs'));
+    this.evaluateHooks(ctx.child('Hooks'));
   }
 
-  private evaluateMappings() {
+  private evaluateMappings(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Mappings');
     this.context.template.mappings.forEach((mapping, mapName) =>
-      new cdk.CfnMapping(scope, mapName, {
-        mapping: mapping.toObject(),
-      }).overrideLogicalId(mapName)
+      ctx.child(mapName).wrap(() => {
+        new cdk.CfnMapping(scope, mapName, {
+          mapping: mapping.toObject(),
+        }).overrideLogicalId(mapName);
+      })
     );
   }
 
   private evaluateParameters(ctx: AnnotationsContext) {
-    ctx.wrap(() => {
-      this.context.template.parameters.forEach((param, paramName) => {
+    this.context.template.parameters.forEach((param, paramName) => {
+      ctx.child(paramName).wrap(() => {
         new cdk.CfnParameter(
           this.context.stack,
           paramName,
@@ -86,53 +96,65 @@ export class Evaluator {
     );
   }
 
-  private evaluateOutputs() {
+  private evaluateOutputs(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Outputs');
     this.context.template.outputs.forEach((output, outputId) => {
-      new DeCDKCfnOutput(scope, outputId, {
-        value: this.evaluate(output.value),
-        description: output.description,
-        exportName: output.exportName
-          ? this.evaluate(output.exportName)
-          : output.exportName,
-        condition: output.conditionName,
-      }).overrideLogicalId(outputId);
+      ctx.child(outputId).wrap(() => {
+        new DeCDKCfnOutput(scope, outputId, {
+          value: this.evaluate(output.value, ctx),
+          description: output.description,
+          exportName: output.exportName
+            ? this.evaluate(output.exportName, ctx)
+            : output.exportName,
+          condition: output.conditionName,
+        }).overrideLogicalId(outputId);
+      });
     });
   }
 
-  private evaluateTransform() {
-    this.context.template.transform.forEach((t) => {
-      this.context.stack.addTransform(t);
+  private evaluateTransform(ctx: AnnotationsContext) {
+    ctx.wrap(() => {
+      this.context.template.transform.forEach((t) => {
+        this.context.stack.addTransform(t);
+      });
     });
   }
 
-  private evaluateMetadata() {
+  private evaluateMetadata(ctx: AnnotationsContext) {
     this.context.template.metadata.forEach((v, k) => {
-      this.context.stack.addMetadata(k, v);
+      ctx.child(k).wrap(() => {
+        this.context.stack.addMetadata(k, v);
+      });
     });
   }
 
-  private evaluateRules() {
+  private evaluateRules(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Rules');
     this.context.template.rules.forEach((rule, name) => {
-      new CfnRule(scope, name, rule).overrideLogicalId(name);
+      ctx.child(name).wrap(() => {
+        new CfnRule(scope, name, rule).overrideLogicalId(name);
+      });
     });
   }
 
-  private evaluateHooks() {
+  private evaluateHooks(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Hooks');
     this.context.template.hooks.forEach((hook, name) => {
-      new CfnHook(scope, name, hook).overrideLogicalId(name);
+      ctx.child(name).wrap(() => {
+        new CfnHook(scope, name, hook).overrideLogicalId(name);
+      });
     });
   }
 
-  private evaluateConditions() {
+  private evaluateConditions(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Conditions');
     this.context.template.conditions.forEach((condition, logicalId) => {
-      const conditionFn = this.evaluate(condition);
-      new cdk.CfnCondition(scope, logicalId, {
-        expression: conditionFn,
-      }).overrideLogicalId(logicalId);
+      ctx.child(logicalId).wrap(() => {
+        const conditionFn = this.evaluate(condition, ctx);
+        new cdk.CfnCondition(scope, logicalId, {
+          expression: conditionFn,
+        }).overrideLogicalId(logicalId);
+      });
     });
   }
 
@@ -146,7 +168,11 @@ export class Evaluator {
     this.applyTags(construct, resource.tags);
     this.applyDependsOn(construct, resource.dependsOn);
     if (isCdkConstructExpression(resource)) {
-      this.applyOverrides(construct, resource.overrides);
+      this.applyOverrides(
+        construct,
+        resource.overrides,
+        ctx.child('Overrides')
+      );
     }
 
     this.context.addReference(
@@ -166,15 +192,7 @@ export class Evaluator {
     return new ConstructReference(logicalId, value as Construct);
   }
 
-  public evaluate(
-    x: TypedTemplateExpression,
-    ctx: AnnotationsContext = this.context.annotations
-  ): any {
-    const ev = (y: TypedTemplateExpression, scope?: string) =>
-      this.evaluate.call(this, y, scope ? ctx.child(scope) : ctx);
-    const maybeEv = (y?: TypedTemplateExpression, scope?: string): any =>
-      y ? ev(y, scope) : undefined;
-
+  public evaluate(x: TypedTemplateExpression, ctx: AnnotationsContext): any {
     try {
       switch (x.type) {
         case 'null':
@@ -191,113 +209,47 @@ export class Evaluator {
         case 'object':
           return this.evaluateObject(x.fields, ctx);
         case 'resolve-reference':
-          return this.resolveReference(x.reference);
+          return this.resolveReference(x.reference, ctx);
         case 'intrinsic':
-          switch (x.fn) {
-            case 'base64':
-              return this.fnBase64(assertString(ev(x.expression)));
-            case 'cidr':
-              return this.fnCidr(
-                ev(x.ipBlock),
-                ev(x.count),
-                maybeEv(x.netMask)
-              );
-            case 'findInMap':
-              return this.fnFindInMap(
-                assertString(ev(x.mappingName)),
-                assertString(ev(x.key1)),
-                assertString(ev(x.key2))
-              );
-            case 'getAtt':
-              return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
-            case 'getProp':
-              return this.fnGetProp(x.logicalId, assertString(x.property));
-            case 'getAzs':
-              return this.fnGetAzs(assertString(ev(x.region)));
-            case 'if':
-              return this.fnIf(x.conditionName, x.then, x.else);
-            case 'importValue':
-              return this.fnImportValue(assertString(ev(x.export)));
-            case 'join':
-              return this.fnJoin(assertString(x.separator), ev(x.list));
-            case 'ref':
-              return this.cfnRef(x.logicalId);
-            case 'select':
-              return this.fnSelect(ev(x.index), ev(x.objects));
-            case 'split':
-              return this.fnSplit(x.separator, assertString(ev(x.value)));
-            case 'sub':
-              return this.fnSub(
-                x.fragments,
-                this.evaluateObject(x.additionalContext, ctx)
-              );
-            case 'transform':
-              return this.fnTransform(
-                x.transformName,
-                this.evaluateObject(x.parameters, ctx)
-              );
-            case 'and':
-              return this.fnAnd(x.operands.map((o) => ev(o)));
-            case 'or':
-              return this.fnOr(x.operands.map((o) => ev(o)));
-            case 'not':
-              return this.fnNot(ev(x.operand));
-            case 'equals':
-              return this.fnEquals(ev(x.value1), ev(x.value2));
-            case 'args':
-              return this.evaluateArray(x.array, ctx);
-            case 'lazyLogicalId':
-              return this.lazyLogicalId(x);
-            case 'length':
-              return this.fnLength(ev(x.list));
-            case 'toJsonString':
-              return this.toJsonString(this.evaluateObject(x.value, ctx));
-          }
+          return this.evaluateIntrinsic(x, ctx);
         case 'enum':
           return this.enum(x.fqn, x.choice);
         case 'staticProperty':
           return this.enum(x.fqn, x.property);
         case 'any':
-          return ev(x.value);
+          return this.evaluate(x.value, ctx);
         case 'void':
           return;
         case 'lazyResource':
-          return this.invoke(x.call, ctx);
+          return this.invoke(x.call, ctx.child('Call'));
         case 'construct':
-          return this.initializeConstruct(x, ev);
+          return this.initializeConstruct(x, ctx);
         case 'cdkObject':
-          return this.initializeCdkObject(x, ev);
+          return this.initializeCdkObject(x, ctx);
         case 'resource':
-          return this.initializeCfnResource(x, ev);
+          return this.initializeCfnResource(x, ctx);
         case 'initializer':
           return this.initializer(x.fqn, this.evaluateArray(x.args.array, ctx));
         case 'staticMethodCall':
-          return this.invokeStaticMethod(
-            x.fqn,
-            x.method,
-            this.evaluateArray(x.args.array, ctx)
-          );
+          return this.invoke(x, ctx);
       }
     } catch (error) {
       ctx.error(new RuntimeError((error as any).message));
     }
   }
 
-  protected initializeCfnResource(
-    x: CfnResourceNode,
-    ev: (x: TypedTemplateExpression, scope?: string) => any
-  ) {
+  protected initializeCfnResource(x: CfnResourceNode, ctx: AnnotationsContext) {
     const resource = this.initializer(x.fqn, [
       this.context.stack,
       x.logicalId,
-      ev(x.props, 'Properties'),
+      this.evaluate(x.props, ctx.child('Properties')),
     ]) as CfnResource;
 
     resource.cfnOptions.creationPolicy = x.creationPolicy
-      ? ev(x.creationPolicy)
+      ? this.evaluate(x.creationPolicy, ctx.child('CreationPolicy'))
       : undefined;
     resource.cfnOptions.updatePolicy = x.updatePolicy
-      ? ev(x.updatePolicy)
+      ? this.evaluate(x.updatePolicy, ctx.child('UpdatePolicy'))
       : undefined;
     resource.cfnOptions.metadata = x.metadata;
     resource.cfnOptions.updateReplacePolicy =
@@ -307,22 +259,18 @@ export class Evaluator {
     return resource;
   }
 
-  protected initializeConstruct(
-    x: CdkConstruct,
-    ev: (x: TypedTemplateExpression, scope?: string) => any
-  ) {
+  protected initializeConstruct(x: CdkConstruct, ctx: AnnotationsContext) {
     return this.initializer(x.fqn, [
       this.context.stack,
       x.logicalId,
-      ev(x.props, 'Properties'),
+      this.evaluate(x.props, ctx.child('Properties')),
     ]);
   }
 
-  protected initializeCdkObject(
-    x: CdkObject,
-    ev: (x: TypedTemplateExpression) => any
-  ) {
-    return this.initializer(x.fqn, [ev(x.props)]);
+  protected initializeCdkObject(x: CdkObject, ctx: AnnotationsContext) {
+    return this.initializer(x.fqn, [
+      this.evaluate(x.props, ctx.child('Properties')),
+    ]);
   }
 
   protected lazyLogicalId(x: LazyLogicalId) {
@@ -353,9 +301,76 @@ export class Evaluator {
     return xs.map((x) => this.evaluate(x, ctx));
   }
 
-  public evaluateCondition(conditionName: string) {
+  public evaluateIntrinsic(x: IntrinsicExpression, ctx: AnnotationsContext) {
+    if (x.fn === 'lazyLogicalId') {
+      return this.lazyLogicalId(x);
+    }
+
+    return ctx.child(intrinsicToLongForm(x.fn)).wrap((intrinsicCtx) => {
+      const ev = (y: TypedTemplateExpression) => this.evaluate(y, intrinsicCtx);
+      const maybeEv = (y?: TypedTemplateExpression): any =>
+        y ? ev(y) : undefined;
+
+      switch (x.fn) {
+        case 'base64':
+          return this.fnBase64(assertString(ev(x.expression)));
+        case 'cidr':
+          return this.fnCidr(ev(x.ipBlock), ev(x.count), maybeEv(x.netMask));
+        case 'findInMap':
+          return this.fnFindInMap(
+            assertString(ev(x.mappingName)),
+            assertString(ev(x.key1)),
+            assertString(ev(x.key2))
+          );
+        case 'getAtt':
+          return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
+        case 'getProp':
+          return this.fnGetProp(x.logicalId, assertString(x.property));
+        case 'getAzs':
+          return this.fnGetAzs(assertString(ev(x.region)));
+        case 'if':
+          return this.fnIf(x.conditionName, x.then, x.else, intrinsicCtx);
+        case 'importValue':
+          return this.fnImportValue(assertString(ev(x.export)));
+        case 'join':
+          return this.fnJoin(assertString(x.separator), ev(x.list));
+        case 'ref':
+          return this.cfnRef(x.logicalId);
+        case 'select':
+          return this.fnSelect(ev(x.index), ev(x.objects));
+        case 'split':
+          return this.fnSplit(x.separator, assertString(ev(x.value)));
+        case 'sub':
+          return this.fnSub(
+            x.fragments,
+            this.evaluateObject(x.additionalContext, intrinsicCtx)
+          );
+        case 'transform':
+          return this.fnTransform(
+            x.transformName,
+            this.evaluateObject(x.parameters, intrinsicCtx)
+          );
+        case 'and':
+          return this.fnAnd(x.operands.map((o) => ev(o)));
+        case 'or':
+          return this.fnOr(x.operands.map((o) => ev(o)));
+        case 'not':
+          return this.fnNot(ev(x.operand));
+        case 'equals':
+          return this.fnEquals(ev(x.value1), ev(x.value2));
+        case 'args':
+          return this.evaluateArray(x.array, intrinsicCtx);
+        case 'length':
+          return this.fnLength(ev(x.list));
+        case 'toJsonString':
+          return this.toJsonString(this.evaluateObject(x.value, intrinsicCtx));
+      }
+    });
+  }
+
+  public evaluateCondition(conditionName: string, ctx: AnnotationsContext) {
     const condition = this.context.condition(conditionName);
-    const result = this.evaluate(condition);
+    const result = this.evaluate(condition, ctx);
     if (typeof result !== 'boolean') {
       throw new Error(
         `Condition does not evaluate to boolean: ${JSON.stringify(result)}`
@@ -368,23 +383,44 @@ export class Evaluator {
     call: StaticMethodCallExpression | InstanceMethodCallExpression,
     ctx: AnnotationsContext
   ) {
-    const parameters = this.evaluateArray(call.args.array, ctx);
+    const evalParams = (
+      args: TypedArrayExpression,
+      innerCtx: AnnotationsContext
+    ) => this.evaluateArray(args.array, innerCtx.child('CDK::Args'));
 
-    return call.type === 'staticMethodCall'
-      ? this.invokeStaticMethod(call.fqn, call.method, parameters)
-      : this.invokeInstanceMethod(call.target, call.method, parameters);
+    if (call.type === 'staticMethodCall') {
+      return ctx.child(`${call.fqn}.${call.method}`).wrap((innerCtx) => {
+        return this.invokeStaticMethod(
+          call.fqn,
+          call.method,
+          evalParams(call.args, innerCtx)
+        );
+      });
+    }
+
+    return ctx
+      .child(`${call.target.reference}.${call.method}`)
+      .wrap((innerCtx) => {
+        return this.invokeInstanceMethod(
+          call.target,
+          call.method,
+          evalParams(call.args, innerCtx),
+          innerCtx
+        );
+      });
   }
 
   private invokeInstanceMethod(
     target: ResolveReferenceExpression,
     method: string,
-    parameters: any[]
+    parameters: any[],
+    ctx: AnnotationsContext
   ) {
-    const instance = this.resolveReference(target.reference);
+    const instance = this.resolveReference(target.reference, ctx);
     return instance[method](...parameters);
   }
 
-  protected invokeStaticMethod(
+  private invokeStaticMethod(
     fqn: string,
     method: string,
     parameters: unknown[]
@@ -446,12 +482,13 @@ export class Evaluator {
   protected fnIf(
     conditionName: string,
     ifYes: TypedTemplateExpression,
-    ifNo: TypedTemplateExpression
+    ifNo: TypedTemplateExpression,
+    ctx: AnnotationsContext
   ) {
     return cdk.Fn.conditionIf(
       conditionName,
-      this.evaluate(ifYes),
-      this.evaluate(ifNo)
+      this.evaluate(ifYes, ctx),
+      this.evaluate(ifNo, ctx)
     );
   }
 
@@ -463,20 +500,25 @@ export class Evaluator {
     return cdk.Fn.join(separator, array);
   }
 
-  protected resolveReference(intrinsic: RefIntrinsic | GetPropIntrinsic) {
+  protected resolveReference(
+    intrinsic: RefIntrinsic | GetPropIntrinsic,
+    ctx: AnnotationsContext
+  ) {
     const { logicalId, fn } = intrinsic;
 
-    const c = this.context.reference(logicalId);
-
     if (fn !== 'ref') {
-      return this.evaluate(intrinsic);
+      return this.evaluateIntrinsic(intrinsic, ctx);
     }
 
-    if (!c.instance) {
-      return this.cfnRef(logicalId);
-    }
+    return ctx.child('Ref').wrap(() => {
+      const c = this.context.reference(logicalId);
 
-    return c.instance;
+      if (!c.instance) {
+        return this.cfnRef(logicalId);
+      }
+
+      return c.instance;
+    });
   }
 
   protected cfnRef(logicalId: string) {
@@ -582,9 +624,10 @@ export class Evaluator {
 
   protected applyOverrides(
     resource: IConstruct,
-    overrides: ResourceOverride[]
+    overrides: ResourceOverride[],
+    ctx: AnnotationsContext
   ) {
-    const ev = this.evaluate.bind(this);
+    const ev = (x: TypedTemplateExpression) => this.evaluate(x, ctx);
     overrides.forEach((override: ResourceOverride) => {
       applyOverride(resource, override, ev);
     });

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -229,7 +229,14 @@ export class Evaluator {
         case 'resource':
           return this.initializeCfnResource(x, ctx);
         case 'initializer':
-          return this.initializer(x.fqn, this.evaluateArray(x.args.array, ctx));
+          return ctx
+            .child(x.fqn)
+            .wrap((innerCtx) =>
+              this.initializer(
+                x.fqn,
+                this.evaluateArray(x.args.array, innerCtx)
+              )
+            );
         case 'staticMethodCall':
           return this.invoke(x, ctx);
       }
@@ -298,7 +305,7 @@ export class Evaluator {
   }
 
   public evaluateArray(xs: TypedTemplateExpression[], ctx: AnnotationsContext) {
-    return xs.map((x) => this.evaluate(x, ctx));
+    return xs.map((x, idx) => this.evaluate(x, ctx.child(idx)));
   }
 
   public evaluateIntrinsic(x: IntrinsicExpression, ctx: AnnotationsContext) {

--- a/src/evaluate/references.ts
+++ b/src/evaluate/references.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { assertObject, ParserError } from '../parser/private/types';
+import { assertObject, SyntaxError } from '../parser/private/types';
 
 function isPropertyOf(
   instance: Record<string, unknown>,
@@ -21,7 +21,7 @@ export function getPropDot(instance: unknown, path: string): unknown {
     if (Array.isArray(o)) {
       const index = parseInt(p);
       if (isNaN(index) || !(0 <= index && index < o.length)) {
-        throw new ParserError(
+        throw new SyntaxError(
           `Expected an integer between 0 and ${o.length - 1}, got ${index}`
         );
       }
@@ -30,7 +30,7 @@ export function getPropDot(instance: unknown, path: string): unknown {
 
     const obj = assertObject(o);
     if (!isPropertyOf(obj, p)) {
-      throw new ParserError(`Expected Construct property path, got: ${path}`);
+      throw new SyntaxError(`Expected Construct property path, got: ${path}`);
     }
     return obj[p];
   }, instance);

--- a/src/evaluate/references.ts
+++ b/src/evaluate/references.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { assertObject, SyntaxError } from '../parser/private/types';
+import { assertObject } from '../parser/private/types';
 
 function isPropertyOf(
   instance: Record<string, unknown>,

--- a/src/parser/private/types.ts
+++ b/src/parser/private/types.ts
@@ -1,13 +1,5 @@
 import { RetentionPolicy } from '../template';
 
-export class SyntaxError extends Error {
-  constructor(msg: string) {
-    super(msg);
-    this.name = 'SyntaxError';
-    Object.setPrototypeOf(this, SyntaxError.prototype);
-  }
-}
-
 export function parseNumber(asString: string | number) {
   const asNumber = parseInt(`${asString}`, 10);
   if (`${asNumber}` !== `${asString}`) {

--- a/src/parser/private/types.ts
+++ b/src/parser/private/types.ts
@@ -1,16 +1,17 @@
 import { RetentionPolicy } from '../template';
 
-export class ParserError extends Error {
+export class SyntaxError extends Error {
   constructor(msg: string) {
     super(msg);
-    Object.setPrototypeOf(this, ParserError.prototype);
+    this.name = 'SyntaxError';
+    Object.setPrototypeOf(this, SyntaxError.prototype);
   }
 }
 
 export function parseNumber(asString: string | number) {
   const asNumber = parseInt(`${asString}`, 10);
   if (`${asNumber}` !== `${asString}`) {
-    throw new ParserError(`Not a number: ${asString}`);
+    throw new SyntaxError(`Not a number: ${asString}`);
   }
   return { asString: `${asNumber}`, asNumber };
 }
@@ -22,7 +23,7 @@ export function assertString(x: unknown): string {
   if (typeof x === 'string') {
     return x;
   }
-  throw new ParserError(`Expected string, got: ${JSON.stringify(x)}`);
+  throw new SyntaxError(`Expected string, got: ${JSON.stringify(x)}`);
 }
 
 export function assertNumber(x: unknown): number {
@@ -32,15 +33,15 @@ export function assertNumber(x: unknown): number {
   if (typeof x === 'string') {
     return parseNumber(x).asNumber;
   }
-  throw new ParserError(`Expected number, got: ${JSON.stringify(x)}`);
+  throw new SyntaxError(`Expected number, got: ${JSON.stringify(x)}`);
 }
 
 export function assertList<T = unknown>(x: unknown, lengths?: number[]): T[] {
   if (!Array.isArray(x)) {
-    throw new ParserError(`Expected list, got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected list, got: ${JSON.stringify(x)}`);
   }
   if (lengths && !lengths.includes(x.length)) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected list of length ${lengths}, got ${x.length}`
     );
   }
@@ -56,7 +57,7 @@ export function assertListOfForm<T>(
     return assertList(x).map(assertForm);
   } catch (e) {
     if (form) {
-      throw new ParserError(
+      throw new SyntaxError(
         `Expected list of form ${form}, got: ${JSON.stringify(x)}`
       );
     }
@@ -76,21 +77,21 @@ export function assertBoolean(x: unknown): boolean {
     case 'false':
       return false;
     default:
-      throw new ParserError(`Expected boolean, got: ${JSON.stringify(x)}`);
+      throw new SyntaxError(`Expected boolean, got: ${JSON.stringify(x)}`);
   }
 }
 
 export function assertTrue(x: unknown): true {
   assertBoolean(x);
   if (x !== true) {
-    throw new ParserError(`Expected 'true', got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected 'true', got: ${JSON.stringify(x)}`);
   }
   return x;
 }
 
 export function assertObject(x: unknown): Record<string, unknown> {
   if (typeof x !== 'object' || x == null || Array.isArray(x)) {
-    throw new ParserError(`Expected object, got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected object, got: ${JSON.stringify(x)}`);
   }
   return x as any;
 }
@@ -100,13 +101,13 @@ export function assertField<A extends object, K extends keyof A>(
   fieldName: K
 ): unknown {
   if (!(fieldName in xs)) {
-    throw new ParserError(`Expected field named '${String(fieldName)}'`);
+    throw new SyntaxError(`Expected field named '${String(fieldName)}'`);
   }
   return xs[fieldName];
 }
 export function assertOneOf<A extends unknown>(x: A, allowed: unknown[]): A {
   if (!allowed.includes(x)) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected one of ${allowed
         .map((f) => `'${String(f)}'`)
         .join('|')}, got: ${JSON.stringify(x)}`
@@ -121,7 +122,7 @@ export function assertExactlyOneOfFields<A extends object, K extends keyof A>(
 ): K {
   const foundFields = fieldNames.filter((f) => f in xs);
   if (foundFields.length !== 1) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected exactly one of the fields ${fieldNames
         .map((f) => `'${String(f)}'`)
         .join(', ')}, got: ${JSON.stringify(xs)}`
@@ -136,7 +137,7 @@ export function assertAtMostOneOfFields<A extends object, K extends keyof A>(
 ): K | undefined {
   const foundFields = fieldNames.filter((f) => f in xs);
   if (foundFields.length > 1) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected at most one of the fields ${fieldNames
         .map((f) => `'${String(f)}'`)
         .join(', ')}, got: ${JSON.stringify(xs)}`
@@ -148,7 +149,7 @@ export function assertAtMostOneOfFields<A extends object, K extends keyof A>(
 export function assertOneField(xs: unknown): string {
   const fields = Object.keys(assertObject(xs));
   if (fields.length !== 1) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected exactly one field, got: ${JSON.stringify(xs)}`
     );
   }
@@ -162,13 +163,13 @@ export function assertStringOrListIntoList(x: unknown): string[] {
   if (Array.isArray(x)) {
     const nonStrings = x.filter((y) => typeof y !== 'string');
     if (nonStrings.length > 0) {
-      throw new ParserError(
+      throw new SyntaxError(
         `Expected all strings in array, found: ${nonStrings}`
       );
     }
     return x as string[];
   }
-  throw new ParserError(
+  throw new SyntaxError(
     `Expected string or list of strings, got: ${JSON.stringify(x)}`
   );
 }
@@ -187,7 +188,7 @@ export function parseRetentionPolicy(x: unknown): RetentionPolicy {
       return 'Snapshot';
   }
 
-  throw new ParserError(
+  throw new SyntaxError(
     `Expected one of Delete|Retain|Snapshot, got: ${JSON.stringify(x)}`
   );
 }
@@ -212,7 +213,7 @@ export function assertOr<T>(
     } catch {}
   }
 
-  throw new ParserError(error(JSON.stringify(x)));
+  throw new SyntaxError(error(JSON.stringify(x)));
 }
 
 export function assertStringOrStringList(xs: unknown): string | string[] {

--- a/src/parser/template/calls.ts
+++ b/src/parser/template/calls.ts
@@ -1,4 +1,4 @@
-import { assertOneField, assertString, ParserError } from '../private/types';
+import { assertOneField, assertString, SyntaxError } from '../private/types';
 import {
   ArrayLiteral,
   parseExpression,
@@ -21,7 +21,7 @@ export function parseCall(x: unknown): FactoryMethodCall | undefined {
     case 2:
       return parseInstanceCall(array);
     default:
-      throw new ParserError(
+      throw new SyntaxError(
         `Method calls should have 1 or 2 elements, got ${array}`
       );
   }

--- a/src/parser/template/calls.ts
+++ b/src/parser/template/calls.ts
@@ -1,4 +1,4 @@
-import { assertOneField, assertString, SyntaxError } from '../private/types';
+import { assertOneField, assertString } from '../private/types';
 import {
   ArrayLiteral,
   parseExpression,

--- a/src/parser/template/expression.ts
+++ b/src/parser/template/expression.ts
@@ -4,7 +4,7 @@ import {
   assertList,
   assertObject,
   assertString,
-  ParserError,
+  SyntaxError,
 } from '../private/types';
 
 export type TemplateExpression =
@@ -239,7 +239,7 @@ export function assertExpression(x: unknown): TemplateExpression {
     'intrinsic',
   ];
   if (!expressionTypes.includes(expressionType)) {
-    throw new ParserError(
+    throw new SyntaxError(
       `Expected ${expressionTypes.join('|')}, got: '${JSON.stringify(
         expressionType
       )}'`
@@ -547,7 +547,7 @@ export function assertIntrinsic<T extends IntrinsicExpression['fn']>(
     }
   }
 
-  throw new ParserError(
+  throw new SyntaxError(
     `Expected one of Intrinsic Functions [${fns.join(
       '|'
     )}], got: ${JSON.stringify(x)}`

--- a/src/parser/template/overrides.ts
+++ b/src/parser/template/overrides.ts
@@ -5,7 +5,7 @@ import {
   assertObject,
   assertString,
   assertTrue,
-  ParserError,
+  SyntaxError,
 } from '../private/types';
 import { ifField, parseExpression, TemplateExpression } from './expression';
 
@@ -53,7 +53,7 @@ function parseOverride(x: unknown): ResourceOverride {
     case 'RemoveResource':
       return parseRemoveResource(override);
     default:
-      throw new ParserError('Unexpected Error');
+      throw new SyntaxError('Unexpected Error');
   }
 }
 

--- a/src/parser/template/overrides.ts
+++ b/src/parser/template/overrides.ts
@@ -5,7 +5,6 @@ import {
   assertObject,
   assertString,
   assertTrue,
-  SyntaxError,
 } from '../private/types';
 import { ifField, parseExpression, TemplateExpression } from './expression';
 

--- a/src/type-resolution/expression.ts
+++ b/src/type-resolution/expression.ts
@@ -1,4 +1,5 @@
 import * as reflect from 'jsii-reflect';
+import { unparseExpression } from '../error-handling/unparse';
 import {
   ArrayExpression,
   BooleanLiteral,
@@ -8,7 +9,6 @@ import {
   ObjectExpression,
   StringLiteral,
   TemplateExpression,
-  unparseExpression,
 } from '../parser/template';
 import {
   InitializerExpression,

--- a/src/type-resolution/primitives.ts
+++ b/src/type-resolution/primitives.ts
@@ -1,5 +1,4 @@
 import * as reflect from 'jsii-reflect';
-import { SyntaxError } from '../parser/private/types';
 import { IntrinsicExpression, TemplateExpression } from '../parser/template';
 
 export interface AnyTemplateExpression {

--- a/src/type-resolution/primitives.ts
+++ b/src/type-resolution/primitives.ts
@@ -1,5 +1,5 @@
 import * as reflect from 'jsii-reflect';
-import { ParserError } from '../parser/private/types';
+import { SyntaxError } from '../parser/private/types';
 import { IntrinsicExpression, TemplateExpression } from '../parser/template';
 
 export interface AnyTemplateExpression {
@@ -28,7 +28,7 @@ export interface VoidExpression {
 
 export function assertVoid(x: unknown): void {
   if (x !== undefined || x !== null) {
-    throw new ParserError(`Expected nothing, got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected nothing, got: ${JSON.stringify(x)}`);
   }
 }
 
@@ -45,7 +45,7 @@ export function assertLiteralOrIntrinsic<
   type: T
 ): (TemplateExpression & { type: T }) | IntrinsicExpression {
   if (![type, 'intrinsic'].includes(x.type)) {
-    throw new ParserError(`Expected ${type}, got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected ${type}, got: ${JSON.stringify(x)}`);
   }
 
   return x as TemplateExpression & { type: T };

--- a/src/type-resolution/references.ts
+++ b/src/type-resolution/references.ts
@@ -1,4 +1,3 @@
-import { SyntaxError } from '../parser/private/types';
 import {
   GetPropIntrinsic,
   RefIntrinsic,

--- a/src/type-resolution/references.ts
+++ b/src/type-resolution/references.ts
@@ -1,4 +1,4 @@
-import { ParserError } from '../parser/private/types';
+import { SyntaxError } from '../parser/private/types';
 import {
   GetPropIntrinsic,
   RefIntrinsic,
@@ -20,7 +20,7 @@ export function resolveRefToValue(x: RefIntrinsic): ResolveReferenceExpression {
 
 export function assertRef(x: TemplateExpression): RefIntrinsic {
   if (x.type !== 'intrinsic' || x.fn !== 'ref') {
-    throw new ParserError(`Expected Ref, got: ${JSON.stringify(x)}`);
+    throw new SyntaxError(`Expected Ref, got: ${JSON.stringify(x)}`);
   }
 
   return x;

--- a/src/type-resolution/union.ts
+++ b/src/type-resolution/union.ts
@@ -1,5 +1,4 @@
 import * as reflect from 'jsii-reflect';
-import { SyntaxError } from '../parser/private/types';
 import { TemplateExpression } from '../parser/template/expression';
 import { TypedTemplateExpression } from './expression';
 import { resolveExpressionType } from './resolve';

--- a/src/type-resolution/union.ts
+++ b/src/type-resolution/union.ts
@@ -1,5 +1,5 @@
 import * as reflect from 'jsii-reflect';
-import { ParserError } from '../parser/private/types';
+import { SyntaxError } from '../parser/private/types';
 import { TemplateExpression } from '../parser/template/expression';
 import { TypedTemplateExpression } from './expression';
 import { resolveExpressionType } from './resolve';
@@ -8,12 +8,12 @@ export function resolveUnionOfTypesExpression(
   x: TemplateExpression,
   unionTypeRefs: reflect.TypeReference[]
 ): TypedTemplateExpression {
-  const errors = new Array<TypeError | ParserError>();
+  const errors = new Array<TypeError | SyntaxError>();
   for (const typeRef of unionTypeRefs) {
     try {
       return resolveExpressionType(x, typeRef);
     } catch (e) {
-      if (!(e instanceof TypeError || e instanceof ParserError)) {
+      if (!(e instanceof TypeError || e instanceof SyntaxError)) {
         throw e;
       }
       errors.push(e);

--- a/test/evaluate/errors.test.ts
+++ b/test/evaluate/errors.test.ts
@@ -94,4 +94,69 @@ suite('Evaluation errors', () => {
       );
     });
   });
+
+  suite('Call wrong method', () => {
+    test('string in place of reference raised an error', async () => {
+      // GIVEN
+      const template = {
+        Parameters: {
+          DomainName: {
+            Type: 'String',
+            Default: 'www.example.com',
+          },
+          HostedZone: { Type: 'String' },
+          CloudFrontOAI: { Type: 'String' },
+        },
+        Resources: {
+          SiteBucket: {
+            Type: 'aws-cdk-lib.aws_s3.Bucket',
+          },
+          SiteCertificate: {
+            Type: 'aws-cdk-lib.aws_certificatemanager.DnsValidatedCertificate',
+            Properties: {
+              domainName: { Ref: 'DomainName' },
+              hostedZone: { Ref: 'HostedZone' },
+              region: { Ref: 'AWS::Region' },
+            },
+          },
+          SiteDistribution: {
+            Type: 'aws-cdk-lib.aws_cloudfront.Distribution',
+            Properties: {
+              certificate: {
+                Ref: 'SiteBucket', // this should be SiteCertificate
+              },
+              defaultRootObject: 'index.html',
+              domainNames: [
+                {
+                  Ref: 'DomainName',
+                },
+              ],
+              minimumProtocolVersion: 'TLS_V1_2_2021',
+              defaultBehavior: {
+                origin: {
+                  'aws-cdk-lib.aws_cloudfront_origins.S3Origin': [
+                    { Ref: 'SiteCertificate' }, // this should be SiteBucket
+                    {
+                      originAccessIdentity: {
+                        Ref: 'CloudFrontOAI',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // THEN
+      const synth = Testing.synth(await Template.fromObject(template), {
+        validateTemplate: false,
+      });
+      await expect(synth).rejects.toThrow(TypeError);
+      await expect(synth).rejects.toThrow(
+        'Expected aws-cdk-lib.aws_s3.IBucket, got: "MyBucket'
+      );
+    });
+  });
 });

--- a/test/evaluate/errors.test.ts
+++ b/test/evaluate/errors.test.ts
@@ -95,30 +95,11 @@ suite('Evaluation errors', () => {
     });
   });
 
-  suite('Call wrong method', () => {
-    test('string in place of reference raised an error', async () => {
+  suite('Multiple errors', () => {
+    test('Evaluation errors are collected', async () => {
       // GIVEN
       const template = {
-        Parameters: {
-          DomainName: {
-            Type: 'String',
-            Default: 'www.example.com',
-          },
-          HostedZone: { Type: 'String' },
-          CloudFrontOAI: { Type: 'String' },
-        },
         Resources: {
-          SiteBucket: {
-            Type: 'aws-cdk-lib.aws_s3.Bucket',
-          },
-          SiteCertificate: {
-            Type: 'aws-cdk-lib.aws_certificatemanager.DnsValidatedCertificate',
-            Properties: {
-              domainName: { Ref: 'DomainName' },
-              hostedZone: { Ref: 'HostedZone' },
-              region: { Ref: 'AWS::Region' },
-            },
-          },
           SiteDistribution: {
             Type: 'aws-cdk-lib.aws_cloudfront.Distribution',
             Properties: {
@@ -153,7 +134,6 @@ suite('Evaluation errors', () => {
       const synth = Testing.synth(await Template.fromObject(template), {
         validateTemplate: false,
       });
-      await expect(synth).rejects.toThrow(TypeError);
       await expect(synth).rejects.toThrow(
         'Expected aws-cdk-lib.aws_s3.IBucket, got: "MyBucket'
       );

--- a/test/evaluate/errors.test.ts
+++ b/test/evaluate/errors.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'expect';
+import { DeclarativeStackError } from '../../src/error-handling';
 import { Template } from '../../src/parser/template';
 import { Testing } from '../util';
 
@@ -129,14 +130,21 @@ suite('Evaluation errors', () => {
           },
         },
       };
-
-      // THEN
       const synth = Testing.synth(await Template.fromObject(template), {
         validateTemplate: false,
       });
-      await expect(synth).rejects.toThrow(
-        'Expected aws-cdk-lib.aws_s3.IBucket, got: "MyBucket'
-      );
+
+      // THEN
+      await expect(synth).rejects.toThrow(DeclarativeStackError);
+      try {
+        await synth;
+      } catch (error) {
+        const msg = error.toString();
+        expect(msg).toContain('No such Resource or Parameter: SiteCertificate');
+        expect(msg).toContain('No such Resource or Parameter: CloudFrontOAI');
+        expect(msg).toContain('No such Resource or Parameter: SiteBucket');
+        expect(msg).toContain('No such Resource or Parameter: DomainName');
+      }
     });
   });
 });


### PR DESCRIPTION
Resolves first part of #410 
Laying the groudwork and collect evaluation errors.

---

Creates errors like below. Note that the formatting is not final. We should probably do some tree based output.
The errors can also be inspected programatically.

```
DeclarativeStackError:

[RuntimeError at Resources.SiteDistribution]
    Cannot read properties of undefined (reading 'bind')

[TypeError at Resources.SiteDistribution.Properties.defaultBehavior.origin."aws-cdk-lib.aws_cloudfront_origins.S3Origin"]
    Cannot read properties of undefined (reading 'isWebsite')

[RuntimeError at Resources.SiteDistribution.Properties.defaultBehavior.origin."aws-cdk-lib.aws_cloudfront_origins.S3Origin".0.Ref]
    No such Resource or Parameter: SiteCertificate

[RuntimeError at Resources.SiteDistribution.Properties.defaultBehavior.origin."aws-cdk-lib.aws_cloudfront_origins.S3Origin".1.originAccessIdentity.Ref]
    No such Resource or Parameter: CloudFrontOAI

[RuntimeError at Resources.SiteDistribution.Properties.certificate.Ref]
    No such Resource or Parameter: SiteBucket

[RuntimeError at Resources.SiteDistribution.Properties.domainNames.0.Ref]
    No such Resource or Parameter: DomainName
```
