### PR TITLE
chore: make lower-level features more extensible

### DIFF
--- a/src/declarative-stack.ts
+++ b/src/declarative-stack.ts
@@ -20,30 +20,12 @@ export class DeclarativeStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: DeclarativeStackProps) {
     super(scope, id, props);
 
-    const {
-      template: { description, metadata, templateFormatVersion },
-    } = props;
-
-    const ctx = metadata.get('AWS::CDK::Context') ?? {};
-    Object.entries(ctx).forEach(([k, v]) => this.node.setContext(k, v));
-
-    this.templateOptions.templateFormatVersion = templateFormatVersion;
-    this.templateOptions.description = description;
-
     const annotations = AnnotationsContext.root();
     const typeSystem = props.typeSystem;
     const template = new TypedTemplate(props.template, {
       annotations,
       typeSystem,
     });
-
-    new (class extends Construct {
-      //@ts-ignore
-      private static readonly [JSII_RTTI_SYMBOL] = {
-        fqn: '@cdklabs/decdk',
-        version,
-      };
-    })(this, '$decdkAnalytics');
 
     const context = new EvaluationContext({
       stack: this,
@@ -54,11 +36,22 @@ export class DeclarativeStack extends cdk.Stack {
 
     _cwd(props.workingDirectory, () => {
       ev.evaluateTemplate(annotations);
+      this.addAnalyticsData();
     });
 
     if (annotations.hasErrors()) {
       throw new DeclarativeStackError(annotations);
     }
+  }
+
+  private addAnalyticsData() {
+    new (class extends Construct {
+      //@ts-ignore
+      private static readonly [JSII_RTTI_SYMBOL] = {
+        fqn: '@cdklabs/decdk',
+        version,
+      };
+    })(this, '$decdkAnalytics');
   }
 }
 

--- a/src/evaluate/context.ts
+++ b/src/evaluate/context.ts
@@ -11,7 +11,11 @@ export interface EvaluationContextOptions {
 }
 class PseudoParamRef extends InstanceReference {}
 
-export class EvaluationContext {
+export interface IEvaluationContext {
+  reference(logicalId: string): Reference;
+}
+
+export class EvaluationContext implements IEvaluationContext {
   public readonly stack: cdk.Stack;
   public readonly typeSystem: reflect.TypeSystem;
   public readonly template: TypedTemplate;

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -44,7 +44,7 @@ import {
 } from '../type-resolution/expression';
 import { DateLiteral } from '../type-resolution/literals';
 import { ResolveReferenceExpression } from '../type-resolution/references';
-import { EvaluationContext } from './context';
+import { EvaluationContext, IEvaluationContext } from './context';
 import { DeCDKCfnOutput } from './outputs';
 import { applyOverride } from './overrides';
 import {
@@ -55,8 +55,8 @@ import {
   ValueOnlyReference,
 } from './references';
 
-export abstract class BaseEvaluator {
-  constructor(public readonly context: EvaluationContext) {}
+export abstract class BaseEvaluator<T extends IEvaluationContext> {
+  constructor(public readonly context: T) {}
 
   public abstract evaluateDescription(ctx: AnnotationsContext): any;
   public abstract evaluateTemplateFormatVersion(ctx: AnnotationsContext): any;
@@ -309,7 +309,7 @@ export abstract class BaseEvaluator {
   }
 }
 
-export class Evaluator extends BaseEvaluator {
+export class Evaluator extends BaseEvaluator<EvaluationContext> {
   public evaluateTemplate(ctx: AnnotationsContext): void {
     const cdkContext =
       this.context.template.metadata.get('AWS::CDK::Context') ?? {};

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -55,8 +55,96 @@ import {
   ValueOnlyReference,
 } from './references';
 
-export class Evaluator {
+export abstract class BaseEvaluator {
   constructor(public readonly context: EvaluationContext) {}
+
+  public abstract evaluateMappings(ctx: AnnotationsContext): any;
+  public abstract evaluateParameters(ctx: AnnotationsContext): any;
+  public abstract evaluateResources(ctx: AnnotationsContext): any;
+  public abstract evaluateOutputs(ctx: AnnotationsContext): any;
+  public abstract evaluateTransform(ctx: AnnotationsContext): any;
+  public abstract evaluateMetadata(ctx: AnnotationsContext): any;
+  public abstract evaluateRules(ctx: AnnotationsContext): any;
+  public abstract evaluateHooks(ctx: AnnotationsContext): any;
+  public abstract evaluateConditions(ctx: AnnotationsContext): any;
+
+  protected abstract evaluateNull(): any;
+  protected abstract evaluateVoid(): any;
+  protected abstract evaluateDate(x: DateLiteral): any;
+  protected abstract evaluatePrimitive(
+    x: StringLiteral | NumberLiteral | BooleanLiteral
+  ): any;
+  protected abstract evaluateCfnResource(
+    x: CfnResourceNode,
+    ctx: AnnotationsContext
+  ): any;
+  protected abstract evaluateConstruct(
+    x: CdkConstruct,
+    ctx: AnnotationsContext
+  ): any;
+  protected abstract evaluateCdkObject(
+    x: CdkObject,
+    ctx: AnnotationsContext
+  ): any;
+  protected abstract evaluateObject(
+    xs: Record<string, TypedTemplateExpression>,
+    ctx: AnnotationsContext
+  ): Record<string, unknown>;
+  protected abstract evaluateArray(
+    xs: TypedTemplateExpression[],
+    ctx: AnnotationsContext
+  ): any;
+
+  protected abstract evaluateCall(
+    call: StaticMethodCallExpression | InstanceMethodCallExpression,
+    ctx: AnnotationsContext
+  ): any;
+  protected abstract evaluateEnum(fqn: string, choice: string): any;
+  protected abstract evaluateInitializer(
+    fqn: string,
+    parameters: unknown[]
+  ): any;
+
+  protected abstract fnBase64(x: string): any;
+  protected abstract fnCidr(
+    ipBlock: string,
+    count: number,
+    sizeMask?: string
+  ): any;
+  protected abstract fnFindInMap(
+    mapName: string,
+    topLevelKey: string,
+    secondLevelKey: string
+  ): any;
+  protected abstract fnGetProp(logicalId: string, prop: string): any;
+  protected abstract fnGetAtt(logicalId: string, attribute: string): any;
+  protected abstract fnGetAzs(region: string): any;
+  protected abstract fnIf(
+    conditionName: string,
+    ifYes: TypedTemplateExpression,
+    ifNo: TypedTemplateExpression,
+    ctx: AnnotationsContext
+  ): any;
+  protected abstract fnImportValue(exportName: string): any;
+  protected abstract fnJoin(separator: string, array: any[]): any;
+  protected abstract fnRef(logicalId: string): any;
+  protected abstract fnSelect(index: number, elements: any[]): any;
+  protected abstract fnSplit(separator: string, value: string): any;
+  protected abstract fnSub(
+    fragments: SubFragment[],
+    additionalContext: Record<string, any>
+  ): any;
+  protected abstract fnTransform(
+    transformName: string,
+    parameters: Record<string, unknown>
+  ): any;
+  protected abstract fnAnd(operands: unknown[]): any;
+  protected abstract fnOr(operands: unknown[]): any;
+  protected abstract fnNot(operand: unknown): any;
+  protected abstract fnEquals(value1: unknown, value2: unknown): any;
+  protected abstract fnLazyLogicalId(x: LazyLogicalId): any;
+  protected abstract fnLength(x: unknown): any;
+  protected abstract fnToJsonString(x: unknown): any;
 
   public evaluateTemplate(ctx: AnnotationsContext) {
     this.evaluateParameters(ctx.child('Parameters'));
@@ -70,6 +158,154 @@ export class Evaluator {
     this.evaluateHooks(ctx.child('Hooks'));
   }
 
+  public evaluate(x: TypedTemplateExpression, ctx: AnnotationsContext): any {
+    try {
+      switch (x.type) {
+        case 'null':
+          return this.evaluateNull();
+        case 'void':
+          return this.evaluateVoid();
+        case 'string':
+        case 'number':
+        case 'boolean':
+          return this.evaluatePrimitive(x);
+        case 'date':
+          return this.evaluateDate(x);
+        case 'array':
+          return this.evaluateArray(x.array, ctx);
+        case 'struct':
+        case 'object':
+          return this.evaluateObject(x.fields, ctx);
+        case 'resolve-reference':
+          return this.resolveReference(x.reference, ctx);
+        case 'intrinsic':
+          return this.evaluateIntrinsic(x, ctx);
+        case 'enum':
+          return this.evaluateEnum(x.fqn, x.choice);
+        case 'staticProperty':
+          return this.evaluateEnum(x.fqn, x.property);
+        case 'any':
+          return this.evaluate(x.value, ctx);
+        case 'lazyResource':
+          return this.evaluateCall(x.call, ctx.child('Call'));
+        case 'construct':
+          return this.evaluateConstruct(x, ctx);
+        case 'cdkObject':
+          return this.evaluateCdkObject(x, ctx);
+        case 'resource':
+          return this.evaluateCfnResource(x, ctx);
+        case 'initializer':
+          return ctx
+            .child(x.fqn)
+            .wrap((innerCtx) =>
+              this.evaluateInitializer(
+                x.fqn,
+                this.evaluateArray(x.args.array, innerCtx)
+              )
+            );
+        case 'staticMethodCall':
+          return this.evaluateCall(x, ctx);
+      }
+    } catch (error) {
+      ctx.error(RuntimeError.wrap(error));
+    }
+  }
+
+  protected evaluateIntrinsic(
+    x: IntrinsicExpression,
+    ctx: AnnotationsContext
+  ): any {
+    if (x.fn === 'lazyLogicalId') {
+      return this.fnLazyLogicalId(x);
+    }
+
+    return ctx.child(intrinsicToLongForm(x.fn)).wrap((intrinsicCtx) => {
+      const ev = (y: TypedTemplateExpression) => this.evaluate(y, intrinsicCtx);
+      const maybeEv = (y?: TypedTemplateExpression): any =>
+        y ? ev(y) : undefined;
+
+      switch (x.fn) {
+        case 'base64':
+          return this.fnBase64(assertString(ev(x.expression)));
+        case 'cidr':
+          return this.fnCidr(ev(x.ipBlock), ev(x.count), maybeEv(x.netMask));
+        case 'findInMap':
+          return this.fnFindInMap(
+            assertString(ev(x.mappingName)),
+            assertString(ev(x.key1)),
+            assertString(ev(x.key2))
+          );
+        case 'getAtt':
+          return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
+        case 'getProp':
+          return this.fnGetProp(x.logicalId, assertString(x.property));
+        case 'getAzs':
+          return this.fnGetAzs(assertString(ev(x.region)));
+        case 'if':
+          return this.fnIf(x.conditionName, x.then, x.else, intrinsicCtx);
+        case 'importValue':
+          return this.fnImportValue(assertString(ev(x.export)));
+        case 'join':
+          return this.fnJoin(assertString(x.separator), ev(x.list));
+        case 'ref':
+          return this.fnRef(x.logicalId);
+        case 'select':
+          return this.fnSelect(ev(x.index), ev(x.objects));
+        case 'split':
+          return this.fnSplit(x.separator, assertString(ev(x.value)));
+        case 'sub':
+          return this.fnSub(
+            x.fragments,
+            this.evaluateObject(x.additionalContext, intrinsicCtx)
+          );
+        case 'transform':
+          return this.fnTransform(
+            x.transformName,
+            this.evaluateObject(x.parameters, intrinsicCtx)
+          );
+        case 'and':
+          return this.fnAnd(x.operands.map((o) => ev(o)));
+        case 'or':
+          return this.fnOr(x.operands.map((o) => ev(o)));
+        case 'not':
+          return this.fnNot(ev(x.operand));
+        case 'equals':
+          return this.fnEquals(ev(x.value1), ev(x.value2));
+        case 'args':
+          return this.evaluateArray(x.array, intrinsicCtx);
+        case 'length':
+          return this.fnLength(ev(x.list));
+        case 'toJsonString':
+          return this.fnToJsonString(
+            this.evaluateObject(x.value, intrinsicCtx)
+          );
+      }
+    });
+  }
+
+  protected resolveReference(
+    intrinsic: RefIntrinsic | GetPropIntrinsic,
+    ctx: AnnotationsContext
+  ) {
+    const { logicalId, fn } = intrinsic;
+
+    if (fn !== 'ref') {
+      return this.evaluateIntrinsic(intrinsic, ctx);
+    }
+
+    return ctx.child('Ref').wrap(() => {
+      const c = this.context.reference(logicalId);
+
+      if (!c.instance) {
+        return this.fnRef(logicalId);
+      }
+
+      return c.instance;
+    });
+  }
+}
+
+export class Evaluator extends BaseEvaluator {
   public evaluateMappings(ctx: AnnotationsContext) {
     const scope = new Construct(this.context.stack, '$Mappings');
     this.context.template.mappings.forEach((mapping, mapName) =>
@@ -196,59 +432,6 @@ export class Evaluator {
     });
   }
 
-  public evaluate(x: TypedTemplateExpression, ctx: AnnotationsContext): any {
-    try {
-      switch (x.type) {
-        case 'null':
-          return this.evaluateNull();
-        case 'void':
-          return this.evaluateVoid();
-        case 'string':
-        case 'number':
-        case 'boolean':
-          return this.evaluatePrimitive(x);
-        case 'date':
-          return this.evaluateDate(x);
-        case 'array':
-          return this.evaluateArray(x.array, ctx);
-        case 'struct':
-        case 'object':
-          return this.evaluateObject(x.fields, ctx);
-        case 'resolve-reference':
-          return this._resolveReference(x.reference, ctx);
-        case 'intrinsic':
-          return this.evaluateIntrinsic(x, ctx);
-        case 'enum':
-          return this.evaluateEnum(x.fqn, x.choice);
-        case 'staticProperty':
-          return this.evaluateEnum(x.fqn, x.property);
-        case 'any':
-          return this.evaluate(x.value, ctx);
-        case 'lazyResource':
-          return this.evaluateCall(x.call, ctx.child('Call'));
-        case 'construct':
-          return this.evaluateConstruct(x, ctx);
-        case 'cdkObject':
-          return this.evaluateCdkObject(x, ctx);
-        case 'resource':
-          return this.evaluateCfnResource(x, ctx);
-        case 'initializer':
-          return ctx
-            .child(x.fqn)
-            .wrap((innerCtx) =>
-              this.evaluateInitializer(
-                x.fqn,
-                this.evaluateArray(x.args.array, innerCtx)
-              )
-            );
-        case 'staticMethodCall':
-          return this.evaluateCall(x, ctx);
-      }
-    } catch (error) {
-      ctx.error(RuntimeError.wrap(error));
-    }
-  }
-
   protected evaluateNull() {
     return undefined;
   }
@@ -318,75 +501,6 @@ export class Evaluator {
     return xs.map((x, idx) => this.evaluate(x, ctx.child(idx)));
   }
 
-  protected evaluateIntrinsic(x: IntrinsicExpression, ctx: AnnotationsContext) {
-    if (x.fn === 'lazyLogicalId') {
-      return this.fnLazyLogicalId(x);
-    }
-
-    return ctx.child(intrinsicToLongForm(x.fn)).wrap((intrinsicCtx) => {
-      const ev = (y: TypedTemplateExpression) => this.evaluate(y, intrinsicCtx);
-      const maybeEv = (y?: TypedTemplateExpression): any =>
-        y ? ev(y) : undefined;
-
-      switch (x.fn) {
-        case 'base64':
-          return this.fnBase64(assertString(ev(x.expression)));
-        case 'cidr':
-          return this.fnCidr(ev(x.ipBlock), ev(x.count), maybeEv(x.netMask));
-        case 'findInMap':
-          return this.fnFindInMap(
-            assertString(ev(x.mappingName)),
-            assertString(ev(x.key1)),
-            assertString(ev(x.key2))
-          );
-        case 'getAtt':
-          return this.fnGetAtt(x.logicalId, assertString(ev(x.attribute)));
-        case 'getProp':
-          return this.fnGetProp(x.logicalId, assertString(x.property));
-        case 'getAzs':
-          return this.fnGetAzs(assertString(ev(x.region)));
-        case 'if':
-          return this.fnIf(x.conditionName, x.then, x.else, intrinsicCtx);
-        case 'importValue':
-          return this.fnImportValue(assertString(ev(x.export)));
-        case 'join':
-          return this.fnJoin(assertString(x.separator), ev(x.list));
-        case 'ref':
-          return this.fnRef(x.logicalId);
-        case 'select':
-          return this.fnSelect(ev(x.index), ev(x.objects));
-        case 'split':
-          return this.fnSplit(x.separator, assertString(ev(x.value)));
-        case 'sub':
-          return this.fnSub(
-            x.fragments,
-            this.evaluateObject(x.additionalContext, intrinsicCtx)
-          );
-        case 'transform':
-          return this.fnTransform(
-            x.transformName,
-            this.evaluateObject(x.parameters, intrinsicCtx)
-          );
-        case 'and':
-          return this.fnAnd(x.operands.map((o) => ev(o)));
-        case 'or':
-          return this.fnOr(x.operands.map((o) => ev(o)));
-        case 'not':
-          return this.fnNot(ev(x.operand));
-        case 'equals':
-          return this.fnEquals(ev(x.value1), ev(x.value2));
-        case 'args':
-          return this.evaluateArray(x.array, intrinsicCtx);
-        case 'length':
-          return this.fnLength(ev(x.list));
-        case 'toJsonString':
-          return this.fnToJsonString(
-            this.evaluateObject(x.value, intrinsicCtx)
-          );
-      }
-    });
-  }
-
   protected evaluateCall(
     call: StaticMethodCallExpression | InstanceMethodCallExpression,
     ctx: AnnotationsContext
@@ -429,7 +543,7 @@ export class Evaluator {
     parameters: any[],
     ctx: AnnotationsContext
   ) {
-    const instance = this._resolveReference(target.reference, ctx);
+    const instance = this.resolveReference(target.reference, ctx);
     return instance[method](...parameters);
   }
 
@@ -440,27 +554,6 @@ export class Evaluator {
   ): any {
     const typeClass = this.context.resolveClass(fqn);
     return typeClass[method](...parameters);
-  }
-
-  private _resolveReference(
-    intrinsic: RefIntrinsic | GetPropIntrinsic,
-    ctx: AnnotationsContext
-  ) {
-    const { logicalId, fn } = intrinsic;
-
-    if (fn !== 'ref') {
-      return this.evaluateIntrinsic(intrinsic, ctx);
-    }
-
-    return ctx.child('Ref').wrap(() => {
-      const c = this.context.reference(logicalId);
-
-      if (!c.instance) {
-        return this.fnRef(logicalId);
-      }
-
-      return c.instance;
-    });
   }
 
   protected evaluateInitializer(fqn: string, parameters: unknown[]): any {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './declarative-stack';
+export * from './error-handling';
+export * from './evaluate';
+export * from './type-resolution';
 export * from './util';

--- a/src/type-resolution/index.ts
+++ b/src/type-resolution/index.ts
@@ -1,2 +1,3 @@
 export * from './resource-like';
 export { resolveExpressionType } from './resolve';
+export * from './template';

--- a/src/type-resolution/template.ts
+++ b/src/type-resolution/template.ts
@@ -21,6 +21,8 @@ export interface TypedTemplateProps {
  * A template describes the desired state of some infrastructure
  */
 export class TypedTemplate {
+  public readonly description?: string;
+  public readonly templateFormatVersion?: string;
   public readonly resources: DependencyGraph<ResourceLike>;
   public readonly parameters: Map<string, TemplateParameter>;
   public readonly conditions: Map<string, TypedTemplateExpression>;
@@ -52,6 +54,8 @@ export class TypedTemplate {
       return node;
     });
 
+    this.description = template.description;
+    this.templateFormatVersion = template.templateFormatVersion;
     this.parameters = template.parameters;
     this.conditions = new Map();
     for (let [logicalId, condition] of template.conditions) {

--- a/test/type-resolution/__snapshots__/fixtures.test.ts.snap
+++ b/test/type-resolution/__snapshots__/fixtures.test.ts.snap
@@ -1984,6 +1984,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/integration.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -2624,6 +2625,7 @@ TypedTemplate {
       "AWS::SecretsManager-2020-07-23",
     ],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [
     "AWS::LanguageExtensions",
     "AWS::SecretsManager-2020-07-23",

--- a/test/type-resolution/__snapshots__/fixtures.test.ts.snap
+++ b/test/type-resolution/__snapshots__/fixtures.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Type Resolution: Fixtures examples/apigw.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a lambda function with an api gateway",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -261,6 +262,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -268,6 +270,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/application-load-balancer.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -912,6 +915,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -919,6 +923,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/ecs.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a Fargate service with necessary resources",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -1316,6 +1321,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -1323,6 +1329,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/fleet.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates an ASG and Vpc",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -1541,6 +1548,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -1548,6 +1556,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/http-proxy.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -1967,6 +1976,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -1974,6 +1984,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/lambda-dashboard.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -2993,6 +3004,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -3000,6 +3012,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/lambda-events.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a lambda function which can be invoked by an sns topic",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -3457,6 +3470,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -3464,6 +3478,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/lambda-layer.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a aws cli lambda layer",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -3643,6 +3658,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -3650,6 +3666,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/lambda-policy.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -4070,6 +4087,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -4077,6 +4095,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/lambda-topic.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -4278,6 +4297,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -4285,6 +4305,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/pipeline.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a CodePipeline along with its CodeCommit repository source",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -4920,6 +4941,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -4927,6 +4949,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures examples/static-site.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -6078,6 +6101,7 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -6085,6 +6109,7 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
 exports[`Type Resolution: Fixtures examples/vpc.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -6148,6 +6173,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -6178,6 +6204,7 @@ TypedTemplate {
       "type": "intrinsic",
     },
   },
+  "description": "AWS CloudFormation Sample Template for using Assertions: Create a load balanced, Auto Scaled sample website where the instances are locked down to only accept traffic from the load balancer. This example creates an Auto Scaling group behind a load balancer with a health check. The web site is available on port 80 or 443 based on the input.",
   "hooks": Map {},
   "mappings": Map {
     "AWSAMIRegionMap" => TemplateMapping {
@@ -9632,6 +9659,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -9653,6 +9681,7 @@ TypedTemplate {
       },
     },
   },
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -10200,6 +10229,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -10207,6 +10237,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-mappings.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {
     "RegionMap" => TemplateMapping {
@@ -10385,6 +10416,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -10392,6 +10424,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-metadata.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {
@@ -10492,6 +10525,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -10499,6 +10533,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-outputs-complex.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -10780,6 +10815,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -10787,6 +10823,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-outputs-simple.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a lambda function with an api gateway",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -11080,6 +11117,7 @@ TypedTemplate {
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -11087,6 +11125,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-parameters.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -11370,6 +11409,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -11377,6 +11417,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/cfn-policies.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -11969,6 +12010,7 @@ yum update -y aws-cfn-bootstrap
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -11976,6 +12018,7 @@ yum update -y aws-cfn-bootstrap
 exports[`Type Resolution: Fixtures templates/cfn-transform.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -12057,6 +12100,7 @@ TypedTemplate {
       "AWS::LanguageExtensions",
     ],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [
     "AWS::LanguageExtensions",
   ],
@@ -12066,6 +12110,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/overrides-delete-path.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {
@@ -12191,6 +12236,7 @@ TypedTemplate {
       "AWS::LanguageExtensions",
     ],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [
     "AWS::LanguageExtensions",
   ],
@@ -12200,6 +12246,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/overrides-remove-resource.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -12342,6 +12389,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -12349,6 +12397,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/overrides-update-path.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": "A template creates a lambda function which can be invoked by an sns topic",
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -12837,6 +12886,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -12844,6 +12894,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/syntax-lambda-policy-from-constructor.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -13120,6 +13171,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;
@@ -13127,6 +13179,7 @@ TypedTemplate {
 exports[`Type Resolution: Fixtures templates/syntax-method-calls.json 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -13944,6 +13997,7 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
     "templateFormatVersion": "2010-09-09",
     "transform": Array [],
   },
+  "templateFormatVersion": "2010-09-09",
   "transform": Array [],
 }
 `;
@@ -13951,6 +14005,7 @@ failed because the id could not be inferred. Use the intrinsic function CDK::Arg
 exports[`Type Resolution: Fixtures templates/syntax-short-intrinsics.yaml 1`] = `
 TypedTemplate {
   "conditions": Map {},
+  "description": undefined,
   "hooks": Map {},
   "mappings": Map {},
   "metadata": Map {},
@@ -14970,6 +15025,7 @@ TypedTemplate {
     "templateFormatVersion": undefined,
     "transform": Array [],
   },
+  "templateFormatVersion": undefined,
   "transform": Array [],
 }
 `;


### PR DESCRIPTION
Adds and exports an abstract `BaseEvaluator` that should make custom implementations much easier.
Also fixes some inconsistencies with features not implemented inside the compiler structure, as defined in [ADR-0007](https://github.com/cdklabs/decdk/blob/57bb22a5d09570f05a09187c3398bb6c68e632d9/docs/architecture/decisions/0007-compiler-stages.md#L1)